### PR TITLE
Fix Japanese Translation based on Prototype UI and "COVID-19" coronavirus name

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Covid19Radar.Android.csproj
+++ b/Covid19Radar/Covid19Radar.Android/Covid19Radar.Android.csproj
@@ -43,6 +43,10 @@
     <AndroidSigningKeyPass>3q4urluv</AndroidSigningKeyPass>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidUseAapt2>true</AndroidUseAapt2>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+    <BundleAssemblies>false</BundleAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ja.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ja.xlf
@@ -1,533 +1,1 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en-US" target-language="ja" original="COVID19RADAR/RESX/APPRESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
-    <header>
-      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.6915.0" tool-company="Microsoft" />
-    </header>
-    <body>
-      <group id="COVID19RADAR/RESOURCES/APPRESOURCES.RESX">
-        <trans-unit id="ButtonIWantToHelp" translate="yes" xml:space="preserve">
-          <source>I want to help</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">私は助けたい</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">I want to help</note>
-        </trans-unit>
-        <trans-unit id="TitleHowItWorks" translate="yes" xml:space="preserve">
-          <source>How it works</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">操作の流れ</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">How it works page title</note>
-        </trans-unit>
-        <trans-unit id="ButtonNext" translate="yes" xml:space="preserve">
-          <source>Next</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">次</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Next button</note>
-        </trans-unit>
-        <trans-unit id="TitleConsentByUserPage" translate="yes" xml:space="preserve">
-          <source>Terms of Service</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">サービス条件</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Consent by user page</note>
-        </trans-unit>
-        <trans-unit id="ButtonAgreeAndProceed" translate="yes" xml:space="preserve">
-          <source>Agree and Proceed</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">同意して続行する</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Agree and Proceed</note>
-        </trans-unit>
-        <trans-unit id="DescriptionPageTextStep1Description" translate="yes" xml:space="preserve">
-          <source>No need to input personal information. We are using unique ID, allocated to you when installing an app.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">個人情報を入力する必要はありません。アプリをインストールするときに割り当てられた一意の ID を使用しています。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 1 description</note>
-        </trans-unit>
-        <trans-unit id="DescriptionPageTextStep2Description" translate="yes" xml:space="preserve">
-          <source>A contact with another app user for longer than 30 min in total, within a radius closer than 2m on average is recorded as "Close Contact".</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">平均2m以上の半径内で、合計で30分以上の他のアプリユーザーとの接触は、「クローズコンタクト」として記録されます。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 2 description</note>
-        </trans-unit>
-        <trans-unit id="DescriptionPageTextStep3Description" translate="yes" xml:space="preserve">
-          <source>Please manually change your status to "Positive" after verifying your phone number."Positive" Workflow , Now coordination with related parties.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">電話番号を確認した後、手動でステータスを 「正の状態」に変更してください。ポジティブ」ワークフロー、今関係者との調整。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 3 description</note>
-        </trans-unit>
-        <trans-unit id="DescriptionPageTextStep4Description" translate="yes" xml:space="preserve">
-          <source>Bluetooth/Exposure Notification needs to be turned on to record close contact. Please go to the next page to turn it on.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">密接な接触を記録するには、Bluetooth をオンにする必要があります。次のページに移動してオンにしてください。</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
-          <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 4 description</note>
-        </trans-unit>
-        <trans-unit id="ButtonStart" translate="yes" xml:space="preserve">
-          <source>Start</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">左端</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Start</note>
-        </trans-unit>
-        <trans-unit id="StartTutorialPageTextProtectingOurLovedOnes" translate="yes" xml:space="preserve">
-          <source>Protecting our loved ones from COVID19</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">COVID19から愛する人を守る</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Protecting our loved ones from COVID19</note>
-        </trans-unit>
-        <trans-unit id="TitleDeviceAccess" translate="yes" xml:space="preserve">
-          <source>Device Access</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">デバイスアクセス</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Device access page title</note>
-        </trans-unit>
-        <trans-unit id="TitleAppDescription" translate="yes" xml:space="preserve">
-          <source>App Description</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">アプリの説明</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">App Description</note>
-        </trans-unit>
-        <trans-unit id="ButtonRegister" translate="yes" xml:space="preserve">
-          <source>Register</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">登録</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Register</note>
-        </trans-unit>
-        <trans-unit id="ButtonAgree" translate="yes" xml:space="preserve">
-          <source>Agree</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">同意する</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Agree</note>
-        </trans-unit>
-        <trans-unit id="HomePageTitle" translate="yes" xml:space="preserve">
-          <source>HOME</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">ホーム</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Home Title</note>
-        </trans-unit>
-        <trans-unit id="AppName" translate="yes" xml:space="preserve">
-          <source>Covid19Radar</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">コヴィド19レーダー</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">App Name</note>
-        </trans-unit>
-        <trans-unit id="HomePageViewStatusSettingsMenu" translate="yes" xml:space="preserve">
-          <source>Status Settings</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">ステータス設定</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Status Settings Menu</note>
-        </trans-unit>
-        <trans-unit id="HomePageViewListOfContributorsMenu" translate="yes" xml:space="preserve">
-          <source>List of Contributors</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">寄稿者一覧</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">List Of Contributors Menu</note>
-        </trans-unit>
-        <trans-unit id="TitleUpdateInformation" translate="yes" xml:space="preserve">
-          <source>Update Information</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">更新情報</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Update Information Menu</note>
-        </trans-unit>
-        <trans-unit id="ButtonHome" translate="yes" xml:space="preserve">
-          <source>HOME</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">ホーム</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">HOME</note>
-        </trans-unit>
-        <trans-unit id="SetupCompletedPageTextYoureReadyToGo" translate="yes" xml:space="preserve">
-          <source>You're ready to go</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">準備ができました</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">You're ready to go</note>
-        </trans-unit>
-        <trans-unit id="TitleSetupCompleted" translate="yes" xml:space="preserve">
-          <source>Set up Completed</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">完了の設定</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Set up Completed</note>
-        </trans-unit>
-        <trans-unit id="UserSettingPageTextStatusSettingsDescription" translate="yes" xml:space="preserve">
-          <source>If you received a positive diagnosis, please enter your mobile number and update your status to protect your loved ones.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">肯定的な診断を受けた場合は、携帯電話番号を入力し、あなたの愛する人を保護するためにあなたのステータスを更新してください。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Status settings page description</note>
-        </trans-unit>
-        <trans-unit id="UserSettingPageTextStatusSettingsEnterNumber" translate="yes" xml:space="preserve">
-          <source>Enter the mobile number</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">携帯電話番号を入力してください</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Status settings page enter number text</note>
-        </trans-unit>
-        <trans-unit id="UserSettingPageTextStatusSettingsSMSDescription" translate="yes" xml:space="preserve">
-          <source>We'll send you a verification code.
-Please check your SMS.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">確認コードをお送りします。
-お使いの SMS を確認してください。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Status settings page verification sms code description</note>
-        </trans-unit>
-        <trans-unit id="UserSettingPageTextStatusSettingsSMSInfo" translate="yes" xml:space="preserve">
-          <source>We will not store your phone number. It will be sent directly to the database of the government.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">電話番号は保存されません。政府のデータベースに直接送信されます。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Status settings page sms info</note>
-        </trans-unit>
-        <trans-unit id="UserSettingPageTextStatusSettingsSubtitle" translate="yes" xml:space="preserve">
-          <source>If you received a positive diagnosis</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">肯定的な診断を受けた場合</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Status settings page sub title</note>
-        </trans-unit>
-        <trans-unit id="UserSettingPageTextPhoneNumberPlaceholder" translate="yes" xml:space="preserve">
-          <source>090-1234-4567</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">090-1234-4567</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Placeholder text for phone number entry</note>
-        </trans-unit>
-        <trans-unit id="DetectedBeaconListMenu" translate="yes" xml:space="preserve">
-          <source>Detected Beacon List</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">検出されたビーコンリスト</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Detected Beacon List Menu</note>
-        </trans-unit>
-        <trans-unit id="InputSmsOTPPageOtpEnterText" translate="yes" xml:space="preserve">
-          <source>Enter the Code that was sent to 
-「{0}」</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">送信されたコードを入力してください
-「{0}」</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Otp Enter the Code</note>
-        </trans-unit>
-        <trans-unit id="TitleOtp" translate="yes" xml:space="preserve">
-          <source>Enter the Code</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">コードを入力してください</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Otp Title</note>
-        </trans-unit>
-        <trans-unit id="ButtonVerify" translate="yes" xml:space="preserve">
-          <source>Verify</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">確認する</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Button Verify</note>
-        </trans-unit>
-        <trans-unit id="InputSmsOTPPageDidntGetTheCodeText" translate="yes" xml:space="preserve">
-          <source>Didn't get the code?</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">コードを取得しませんでしたか?</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Didn't get the code Text</note>
-        </trans-unit>
-        <trans-unit id="InputSmsOTPPageResendText" translate="yes" xml:space="preserve">
-          <source>Resend</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">再送信</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Resend Text</note>
-        </trans-unit>
-        <trans-unit id="StatusUpdateCompletePageTextStatusUpdateComplete" translate="yes" xml:space="preserve">
-          <source>Status Update Complete</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">ステータス更新の完了</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Status Update Complete page text</note>
-        </trans-unit>
-        <trans-unit id="TitleStatusUpdateComplete" translate="yes" xml:space="preserve">
-          <source>Status Update Complete</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">ステータス更新の完了</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Status Update Complete page title</note>
-        </trans-unit>
-        <trans-unit id="TitleContributorsPage" translate="yes" xml:space="preserve">
-          <source>Contributors List</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">寄稿者リスト</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Contributors list page title</note>
-        </trans-unit>
-        <trans-unit id="TitleDetectedBeaconPage" translate="yes" xml:space="preserve">
-          <source>Detected Beacons</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">検出されたビーコン</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Detected Beacons</note>
-        </trans-unit>
-        <trans-unit id="TitleLicenseAgreement" translate="yes" xml:space="preserve">
-          <source>License Agreement</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">使用許諾契約書</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">License Agreement</note>
-        </trans-unit>
-        <trans-unit id="UrlPrivacyPolicy" translate="yes" xml:space="preserve">
-          <source>https://covid19radar.z11.web.core.windows.net/en/privacypolicy.html</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">https://covid19radar.z11.web.core.windows.net/en/privacypolicy.html</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">PrivacyPolicy</note>
-        </trans-unit>
-        <trans-unit id="DetectedBeaconPageTextId" translate="yes" xml:space="preserve">
-          <source>ID</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">ID</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">ID</note>
-        </trans-unit>
-        <trans-unit id="DetectedBeaconPageTextAvgDistance" translate="yes" xml:space="preserve">
-          <source>Average Distance</source>
-          <target state="translated" state-qualifier="mt-suggestion">平均距離</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">TextAvgDistance</note>
-        </trans-unit>
-        <trans-unit id="DetectedBeaconPageTextCount" translate="yes" xml:space="preserve">
-          <source>Count</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">カウント</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">TextCount</note>
-        </trans-unit>
-        <trans-unit id="DetectedBeaconPageTextElapsedTime" translate="yes" xml:space="preserve">
-          <source>ElapsedTime</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">経過時間</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">TextElapsedTime</note>
-        </trans-unit>
-        <trans-unit id="DetectedBeaconPageTextLastTime" translate="yes" xml:space="preserve">
-          <source>LastTime</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">ラストタイム</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">TextLastTime</note>
-        </trans-unit>
-        <trans-unit id="DetectedBeaconPageTextMajorNo" translate="yes" xml:space="preserve">
-          <source>MajorNo</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">メジャーなし</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">MajorNo</note>
-        </trans-unit>
-        <trans-unit id="DetectedBeaconPageTextMinorNo" translate="yes" xml:space="preserve">
-          <source>MinorNo</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">マイナーなし</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">MinorNo</note>
-        </trans-unit>
-        <trans-unit id="UrlContributor" translate="yes" xml:space="preserve">
-          <source>https://covid19radar.z11.web.core.windows.net/en/contributor.html</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">https://covid19radar.z11.web.core.windows.net/en/contributor.html</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Url Contributor</note>
-        </trans-unit>
-        <trans-unit id="UrlUpdate" translate="yes" xml:space="preserve">
-          <source>https://covid19radar.z11.web.core.windows.net/en/update.html</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">https://covid19radar.z11.web.core.windows.net/en/update.html</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Update</note>
-        </trans-unit>
-        <trans-unit id="TitleHeadsup" translate="yes" xml:space="preserve">
-          <source>Heads up</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">ヘッズアップ</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Heads up</note>
-        </trans-unit>
-        <trans-unit id="UrlHeadsup" translate="yes" xml:space="preserve">
-          <source>https://covid19radar.z11.web.core.windows.net/en/qna.html</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">https://covid19radar.z11.web.core.windows.net/en/qna.html</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">If contacted , headsup and Correct coping method and contact information Try to be calm.</note>
-        </trans-unit>
-        <trans-unit id="DescriptionPageTitleTextStep1" translate="yes" xml:space="preserve">
-          <source>Installing an App</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">アプリのインストール</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 1 title</note>
-        </trans-unit>
-        <trans-unit id="DescriptionPageTitleTextStep2" translate="yes" xml:space="preserve">
-          <source>Recording Close Contact</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">密接な連絡先の記録</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 2 title</note>
-        </trans-unit>
-        <trans-unit id="DescriptionPageTitleTextStep3" translate="yes" xml:space="preserve">
-          <source>If you are diagnosed COVID19 positive</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">COVID19陽性と診断された場合</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 3 title</note>
-        </trans-unit>
-        <trans-unit id="DescriptionPageTitleTextStep4" translate="yes" xml:space="preserve">
-          <source>Requirements to use this app</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">このアプリを使用するための要件</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 4 title</note>
-        </trans-unit>
-        <trans-unit id="TitleUserSettings" translate="yes" xml:space="preserve">
-          <source>Status Settings</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">ステータス設定</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Status Settings page title</note>
-        </trans-unit>
-        <trans-unit id="TitileUserStatusSettings" translate="yes" xml:space="preserve">
-          <source>Status Settings</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">ステータス設定</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">User Status Page Title</note>
-        </trans-unit>
-        <trans-unit id="ButtonSave" translate="yes" xml:space="preserve">
-          <source>Save</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">保存</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Button Save</note>
-        </trans-unit>
-        <trans-unit id="UserStatusPageTextStatusSettingsDescription" translate="yes" xml:space="preserve">
-          <source>If you received a positive diagnosis, please enter your mobile number and update your status to protect your loved ones.</source>
-          <target state="translated" state-qualifier="mt-suggestion">陽性の診断結果を受けた場合は、携帯電話番号を入力し、あなたの愛する人を保護するためにあなたのステータスを更新してください。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">User Status Page description</note>
-        </trans-unit>
-        <trans-unit id="UserStatusPageTextStatusSettingsPickerTitle" translate="yes" xml:space="preserve">
-          <source>Tap to change state</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">タップして状態を変更する</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">User Status Page Status Change</note>
-        </trans-unit>
-        <trans-unit id="DialogNetworkConnectionError" translate="yes" xml:space="preserve">
-          <source>Please check your network connection.</source>
-          <target state="translated">ネットワーク接続を確認してください。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Dialog message for Network connection error</note>
-        </trans-unit>
-        <trans-unit id="DialogButtonOk" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">オーケー</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">OK</note>
-        </trans-unit>
-        <trans-unit id="ButtonEnable" translate="yes" xml:space="preserve">
-          <source>Enable</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">有効にする</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Enable Button</note>
-        </trans-unit>
-        <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">今はない</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">NotNow Button</note>
-        </trans-unit>
-        <trans-unit id="InitSettingPageTextExposureNotificationDescription" translate="yes" xml:space="preserve">
-          <source>This app uses Exposure Notification / Bluetooth signals to determine if you are near another contact tracing app user. 
-Select 'Always Allow' to set up Bluetooth.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">このアプリは、あなたが別の連絡先トレースアプリのユーザーの近くにいるかどうかを判断するために露出通知/ブルートゥース信号を使用しています。
-Bluetooth を設定するには、[常に許可] を選択します。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Device access page Allow Exposure Notification / Bluetooth description</note>
-        </trans-unit>
-        <trans-unit id="InitSettingPageTextExposureNotification" translate="yes" xml:space="preserve">
-          <source>Allow Exposure Notification / Bluetooth</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">露出通知を許可する / ブルートゥース</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Device access page Allow Exposure Notification / Bluetooth title</note>
-        </trans-unit>
-        <trans-unit id="MainContributors" translate="yes" xml:space="preserve">
-          <source>Contributors</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">貢献</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Tab Contributors</note>
-        </trans-unit>
-        <trans-unit id="MainExposures" translate="yes" xml:space="preserve">
-          <source>Exposures</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">エクスポー ジャー</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Tab Button</note>
-        </trans-unit>
-        <trans-unit id="MainHome" translate="yes" xml:space="preserve">
-          <source>Home</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">ホーム</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Tab Home</note>
-        </trans-unit>
-        <trans-unit id="MainLicense" translate="yes" xml:space="preserve">
-          <source>License</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">ライセンス</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Tab License</note>
-        </trans-unit>
-        <trans-unit id="MainNotifyOther" translate="yes" xml:space="preserve">
-          <source>Notify</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">通知</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Tab Notify</note>
-        </trans-unit>
-        <trans-unit id="MainUpdateInfo" translate="yes" xml:space="preserve">
-          <source>Update</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">更新プログラム</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Tab Button</note>
-        </trans-unit>
-        <trans-unit id="TitleExposures" translate="yes" xml:space="preserve">
-          <source>Exposures</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">エクスポー ジャー</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Exposures Page</note>
-        </trans-unit>
-        <trans-unit id="NotifyOthersLearnMoreUrl" translate="yes" xml:space="preserve">
-          <source>https://microsoft.com/</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">https://microsoft.com/</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Health care jurisdiction page</note>
-        </trans-unit>
-        <trans-unit id="MainTutorial" translate="yes" xml:space="preserve">
-          <source>Manual</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">手動</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Tab How to use</note>
-        </trans-unit>
-        <trans-unit id="HomePageUpdateInfomation" translate="yes" xml:space="preserve">
-          <source>Update Infomation</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">情報の更新</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Home Page Update Infomation text</note>
-        </trans-unit>
-        <trans-unit id="HomeEnableNotification" translate="yes" xml:space="preserve">
-          <source>Enable Notification</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">通知を有効にする</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Home Setting Enable Notification</note>
-        </trans-unit>
-        <trans-unit id="ExposuresPageNoExposures" translate="yes" xml:space="preserve">
-          <source>No known exposures</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">既知の露出はありません</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">If not found exposures data</note>
-        </trans-unit>
-        <trans-unit id="ExposuresPageNoExposuresInfo" translate="yes" xml:space="preserve">
-          <source>You will be notified if you have been exposed to someone who reported a positive COVID-19 result.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">COVID-19の肯定的な結果を報告した人に公開された場合は、通知されます。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">exposures comment</note>
-        </trans-unit>
-        <trans-unit id="NofityPageButtonSharePositive" translate="yes" xml:space="preserve">
-          <source>Share A Positive Diagnosis</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">肯定的な診断を共有する</target>
-        </trans-unit>
-        <trans-unit id="NofityPageShareDiag" translate="yes" xml:space="preserve">
-          <source>Share A Positive Diagnosis</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">肯定的な診断を共有する</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Notify Page Share Diag</note>
-        </trans-unit>
-        <trans-unit id="NofityPageShareYourCase" translate="yes" xml:space="preserve">
-          <source>If you tested positive for the virus that causes COVID-19, you can choose to share your diagnosis.  This will help others in your community contain the spread of the virus.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">COVID-19の原因となるウイルスの陽性をテストした場合は、診断を共有することを選択できます。 これは、あなたのコミュニティの他の人がウイルスの拡散を含むのに役立ちます.</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">NofityPageShareYourCase</note>
-        </trans-unit>
-        <trans-unit id="NotifyPageLearnMore" translate="yes" xml:space="preserve">
-          <source>Learn more</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">詳細</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Notify Page Learn more text</note>
-        </trans-unit>
-        <trans-unit id="NotifyOtherPageTextStatusSettingsSubtitle" translate="yes" xml:space="preserve">
-          <source>If you received a positive diagnosis</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">肯定的な診断を受けた場合</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">User Status Page subtitle</note>
-        </trans-unit>
-        <trans-unit id="NotifyOtherPageCodePlaceholder" translate="yes" xml:space="preserve">
-          <source>Please enter the Diagnosis Identifier</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">診断識別子を入力してください</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Notify Other Page Code Input</note>
-        </trans-unit>
-        <trans-unit id="TitileSharePositiveDiagnosis" translate="yes" xml:space="preserve">
-          <source>Share a Positive Diagnosis</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">肯定的な診断を共有する</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagDateText" translate="yes" xml:space="preserve">
-          <source>The test date helps the app know when you may have been contagious and notify the right people of potential exposure.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">テスト日は、あなたが伝染した可能性があるときにアプリを知り、潜在的な暴露を適切な人々に通知するのに役立ちます。</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveEntryCodeText" translate="yes" xml:space="preserve">
-          <source>Only those who have been exposed will receive a notification.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">公開されたユーザーのみが通知を受け取ります。</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveEntryCodeText2" translate="yes" xml:space="preserve">
-          <source>The unique test identifier that came with your COVID-19 test must be used to verify your positive test result.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">COVID-19 テストに付属の一意のテスト ID を使用して、陽性のテスト結果を検証する必要があります。</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveSubmitAndVerify" translate="yes" xml:space="preserve">
-          <source>Verify and Share</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">確認と共有</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Verify and Share</note>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageDiagExceptionText" translate="yes" xml:space="preserve">
-          <source>Please try again later.</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">後でもう一度試してください。</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageDiagExceptionTitle" translate="yes" xml:space="preserve">
-          <source>Failed</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">失敗</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageDiagSubmittedText" translate="yes" xml:space="preserve">
-          <source>Diagnosis Submitted</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">診断提出</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageDiagSubmittedTitle" translate="yes" xml:space="preserve">
-          <source>Complete</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">完了しました</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageDiagUidIsEmptyText" translate="yes" xml:space="preserve">
-          <source>Please provide a Diagnosis Identifier</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">診断識別子を指定してください</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageDiagUidIsEmptyTitle" translate="yes" xml:space="preserve">
-          <source>Diagnosis Identifier Required</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">診断識別子が必要です</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageDialogButton" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">オーケー</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageNotEnabledENDialogText" translate="yes" xml:space="preserve">
-          <source>Please enable Exposure Notifications before submitting a diagnosis.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">診断を送信する前に露出通知を有効にしてください。</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageNotEnabledENDialogTitle" translate="yes" xml:space="preserve">
-          <source>Exposure Notifications Disabled</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">露出通知が無効</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageSubmittingDialog" translate="yes" xml:space="preserve">
-          <source>Submitting Diagnosis...</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">診断を提出します。</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageVerifyDialog" translate="yes" xml:space="preserve">
-          <source>Verifying Diagnosis...</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">診断を確認しています。</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageVerifyFailedDialogText" translate="yes" xml:space="preserve">
-          <source>Your diagnosis cannot be verified at this time to be submitted.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">現時点では、診断を確認できません。</target>
-        </trans-unit>
-        <trans-unit id="SharePositiveDiagnosisPageVerifyFailedDialogTitle" translate="yes" xml:space="preserve">
-          <source>Verification Failed</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">検証に失敗しました</target>
-        </trans-unit>
-        <trans-unit id="ButtonPositiveSubmit" translate="yes" xml:space="preserve">
-          <source>Submit</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">提出</target>
-        </trans-unit>
-        <trans-unit id="DescriptionPageTextStep1Description2" translate="yes" xml:space="preserve">
-          <source>SampleText</source>
-          <target state="new">SampleText</target>
-        </trans-unit>
-        <trans-unit id="DescriptionPageTextStep2Description2" translate="yes" xml:space="preserve">
-          <source>SampleText</source>
-          <target state="new">SampleText</target>
-        </trans-unit>
-      </group>
-    </body>
-  </file>
-</xliff>
+﻿<?xml version="1.0" encoding="utf-8"?> <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">   <file datatype="xml" source-language="en-US" target-language="ja" original="COVID19RADAR/RESX/APPRESOURCES.RESX" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">     <header>       <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.6915.0" tool-company="Microsoft" />     </header>     <body>       <group id="COVID19RADAR/RESOURCES/APPRESOURCES.RESX">         <trans-unit id="ButtonIWantToHelp" translate="yes" xml:space="preserve">           <source>I want to help</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">私は助けたい</target>           <note from="MultilingualBuild" annotates="source" priority="2">I want to help</note>         </trans-unit>         <trans-unit id="TitleHowItWorks" translate="yes" xml:space="preserve">           <source>How it works</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">操作の流れ</target>           <note from="MultilingualBuild" annotates="source" priority="2">How it works page title</note>         </trans-unit>         <trans-unit id="ButtonNext" translate="yes" xml:space="preserve">           <source>Next</source>           <target state="translated" state-qualifier="tm-suggestion">次へ</target>           <note from="MultilingualBuild" annotates="source" priority="2">Next button</note>         </trans-unit>         <trans-unit id="TitleConsentByUserPage" translate="yes" xml:space="preserve">           <source>Terms of Service</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">サービス条件</target>           <note from="MultilingualBuild" annotates="source" priority="2">Consent by user page</note>         </trans-unit>         <trans-unit id="ButtonAgreeAndProceed" translate="yes" xml:space="preserve">           <source>Agree and Proceed</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">同意して続行する</target>           <note from="MultilingualBuild" annotates="source" priority="2">Agree and Proceed</note>         </trans-unit>         <trans-unit id="DescriptionPageTextStep1Description" translate="yes" xml:space="preserve">           <source>No need to input personal information. We are using unique ID, allocated to you when installing an app.</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">個人情報を入力する必要はありません。アプリをインストールするときに割り当てられた一意の ID を使用しています。</target>           <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 1 description</note>         </trans-unit>         <trans-unit id="DescriptionPageTextStep2Description" translate="yes" xml:space="preserve">           <source>A contact with another app user for longer than 30 min in total, within a radius closer than 2m on average is recorded as "Close Contact".</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">平均2m以上の半径内で、合計で30分以上の他のアプリユーザーとの接触は、「クローズコンタクト」として記録されます。</target>           <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 2 description</note>         </trans-unit>         <trans-unit id="DescriptionPageTextStep3Description" translate="yes" xml:space="preserve">           <source>Please manually change your status to "Positive" after verifying your phone number."Positive" Workflow , Now coordination with related parties.</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">電話番号を確認した後、手動でステータスを 「正の状態」に変更してください。ポジティブ」ワークフロー、今関係者との調整。</target>           <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 3 description</note>         </trans-unit>         <trans-unit id="DescriptionPageTextStep4Description" translate="yes" xml:space="preserve">           <source>Bluetooth/Exposure Notification needs to be turned on to record close contact. Please go to the next page to turn it on.</source>           <target state="translated" state-qualifier="mt-suggestion">濃厚接触を記録するには、Bluetooth を有効にする必要があります。次のページに移動して有効にしてください。</target>           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>           <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 4 description</note>         </trans-unit>         <trans-unit id="ButtonStart" translate="yes" xml:space="preserve">           <source>Start</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">左端</target>           <note from="MultilingualBuild" annotates="source" priority="2">Start</note>         </trans-unit>         <trans-unit id="StartTutorialPageTextProtectingOurLovedOnes" translate="yes" xml:space="preserve">           <source>Protecting our loved ones from COVID19</source>           <target state="translated" state-qualifier="mt-suggestion">大切な人をCOVID-19から一緒に守りましょう</target>           <note from="MultilingualBuild" annotates="source" priority="2">Protecting our loved ones from COVID19</note>         </trans-unit>         <trans-unit id="TitleDeviceAccess" translate="yes" xml:space="preserve">           <source>Device Access</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">デバイスアクセス</target>           <note from="MultilingualBuild" annotates="source" priority="2">Device access page title</note>         </trans-unit>         <trans-unit id="TitleAppDescription" translate="yes" xml:space="preserve">           <source>App Description</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">アプリの説明</target>           <note from="MultilingualBuild" annotates="source" priority="2">App Description</note>         </trans-unit>         <trans-unit id="ButtonRegister" translate="yes" xml:space="preserve">           <source>Register</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">登録</target>           <note from="MultilingualBuild" annotates="source" priority="2">Register</note>         </trans-unit>         <trans-unit id="ButtonAgree" translate="yes" xml:space="preserve">           <source>Agree</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">同意する</target>           <note from="MultilingualBuild" annotates="source" priority="2">Agree</note>         </trans-unit>         <trans-unit id="HomePageTitle" translate="yes" xml:space="preserve">           <source>HOME</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">ホーム</target>           <note from="MultilingualBuild" annotates="source" priority="2">Home Title</note>         </trans-unit>         <trans-unit id="AppName" translate="yes" xml:space="preserve">           <source>Covid19Radar</source>           <target state="translated" state-qualifier="mt-suggestion">Covid19Radar</target>           <note from="MultilingualBuild" annotates="source" priority="2">App Name</note>         </trans-unit>         <trans-unit id="HomePageViewStatusSettingsMenu" translate="yes" xml:space="preserve">           <source>Status Settings</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">ステータス設定</target>           <note from="MultilingualBuild" annotates="source" priority="2">Status Settings Menu</note>         </trans-unit>         <trans-unit id="HomePageViewListOfContributorsMenu" translate="yes" xml:space="preserve">           <source>List of Contributors</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">寄稿者一覧</target>           <note from="MultilingualBuild" annotates="source" priority="2">List Of Contributors Menu</note>         </trans-unit>         <trans-unit id="TitleUpdateInformation" translate="yes" xml:space="preserve">           <source>Update Information</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">更新情報</target>           <note from="MultilingualBuild" annotates="source" priority="2">Update Information Menu</note>         </trans-unit>         <trans-unit id="ButtonHome" translate="yes" xml:space="preserve">           <source>HOME</source>           <target state="translated" state-qualifier="tm-suggestion">ホームへ</target>           <note from="MultilingualBuild" annotates="source" priority="2">HOME</note>         </trans-unit>         <trans-unit id="SetupCompletedPageTextYoureReadyToGo" translate="yes" xml:space="preserve">           <source>You're ready to go</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">準備ができました</target>           <note from="MultilingualBuild" annotates="source" priority="2">You're ready to go</note>         </trans-unit>         <trans-unit id="TitleSetupCompleted" translate="yes" xml:space="preserve">           <source>Set up Completed</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">完了の設定</target>           <note from="MultilingualBuild" annotates="source" priority="2">Set up Completed</note>         </trans-unit>         <trans-unit id="UserSettingPageTextStatusSettingsDescription" translate="yes" xml:space="preserve">           <source>If you received a positive diagnosis, please enter your mobile number and update your status to protect your loved ones.</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">肯定的な診断を受けた場合は、携帯電話番号を入力し、あなたの愛する人を保護するためにあなたのステータスを更新してください。</target>           <note from="MultilingualBuild" annotates="source" priority="2">Status settings page description</note>         </trans-unit>         <trans-unit id="UserSettingPageTextStatusSettingsEnterNumber" translate="yes" xml:space="preserve">           <source>Enter the mobile number</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">携帯電話番号を入力してください</target>           <note from="MultilingualBuild" annotates="source" priority="2">Status settings page enter number text</note>         </trans-unit>         <trans-unit id="UserSettingPageTextStatusSettingsSMSDescription" translate="yes" xml:space="preserve">           <source>We'll send you a verification code. Please check your SMS.</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">確認コードをお送りします。 お使いの SMS を確認してください。</target>           <note from="MultilingualBuild" annotates="source" priority="2">Status settings page verification sms code description</note>         </trans-unit>         <trans-unit id="UserSettingPageTextStatusSettingsSMSInfo" translate="yes" xml:space="preserve">           <source>We will not store your phone number. It will be sent directly to the database of the government.</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">電話番号は保存されません。政府のデータベースに直接送信されます。</target>           <note from="MultilingualBuild" annotates="source" priority="2">Status settings page sms info</note>         </trans-unit>         <trans-unit id="UserSettingPageTextStatusSettingsSubtitle" translate="yes" xml:space="preserve">           <source>If you received a positive diagnosis</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">肯定的な診断を受けた場合</target>           <note from="MultilingualBuild" annotates="source" priority="2">Status settings page sub title</note>         </trans-unit>         <trans-unit id="UserSettingPageTextPhoneNumberPlaceholder" translate="yes" xml:space="preserve">           <source>090-1234-4567</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">090-1234-4567</target>           <note from="MultilingualBuild" annotates="source" priority="2">Placeholder text for phone number entry</note>         </trans-unit>         <trans-unit id="DetectedBeaconListMenu" translate="yes" xml:space="preserve">           <source>Detected Beacon List</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">検出されたビーコンリスト</target>           <note from="MultilingualBuild" annotates="source" priority="2">Detected Beacon List Menu</note>         </trans-unit>         <trans-unit id="InputSmsOTPPageOtpEnterText" translate="yes" xml:space="preserve">           <source>Enter the Code that was sent to  「{0}」</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">送信されたコードを入力してください 「{0}」</target>           <note from="MultilingualBuild" annotates="source" priority="2">Otp Enter the Code</note>         </trans-unit>         <trans-unit id="TitleOtp" translate="yes" xml:space="preserve">           <source>Enter the Code</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">コードを入力してください</target>           <note from="MultilingualBuild" annotates="source" priority="2">Otp Title</note>         </trans-unit>         <trans-unit id="ButtonVerify" translate="yes" xml:space="preserve">           <source>Verify</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">確認する</target>           <note from="MultilingualBuild" annotates="source" priority="2">Button Verify</note>         </trans-unit>         <trans-unit id="InputSmsOTPPageDidntGetTheCodeText" translate="yes" xml:space="preserve">           <source>Didn't get the code?</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">コードを取得しませんでしたか?</target>           <note from="MultilingualBuild" annotates="source" priority="2">Didn't get the code Text</note>         </trans-unit>         <trans-unit id="InputSmsOTPPageResendText" translate="yes" xml:space="preserve">           <source>Resend</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">再送信</target>           <note from="MultilingualBuild" annotates="source" priority="2">Resend Text</note>         </trans-unit>         <trans-unit id="StatusUpdateCompletePageTextStatusUpdateComplete" translate="yes" xml:space="preserve">           <source>Status Update Complete</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">ステータス更新の完了</target>           <note from="MultilingualBuild" annotates="source" priority="2">Status Update Complete page text</note>         </trans-unit>         <trans-unit id="TitleStatusUpdateComplete" translate="yes" xml:space="preserve">           <source>Status Update Complete</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">ステータス更新の完了</target>           <note from="MultilingualBuild" annotates="source" priority="2">Status Update Complete page title</note>         </trans-unit>         <trans-unit id="TitleContributorsPage" translate="yes" xml:space="preserve">           <source>Contributors List</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">寄稿者リスト</target>           <note from="MultilingualBuild" annotates="source" priority="2">Contributors list page title</note>         </trans-unit>         <trans-unit id="TitleDetectedBeaconPage" translate="yes" xml:space="preserve">           <source>Detected Beacons</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">検出されたビーコン</target>           <note from="MultilingualBuild" annotates="source" priority="2">Detected Beacons</note>         </trans-unit>         <trans-unit id="TitleLicenseAgreement" translate="yes" xml:space="preserve">           <source>License Agreement</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">使用許諾契約書</target>           <note from="MultilingualBuild" annotates="source" priority="2">License Agreement</note>         </trans-unit>         <trans-unit id="UrlPrivacyPolicy" translate="yes" xml:space="preserve">           <source>https://covid19radar.z11.web.core.windows.net/en/privacypolicy.html</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">https://covid19radar.z11.web.core.windows.net/en/privacypolicy.html</target>           <note from="MultilingualBuild" annotates="source" priority="2">PrivacyPolicy</note>         </trans-unit>         <trans-unit id="DetectedBeaconPageTextId" translate="yes" xml:space="preserve">           <source>ID</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">ID</target>           <note from="MultilingualBuild" annotates="source" priority="2">ID</note>         </trans-unit>         <trans-unit id="DetectedBeaconPageTextAvgDistance" translate="yes" xml:space="preserve">           <source>Average Distance</source>           <target state="translated" state-qualifier="mt-suggestion">平均距離</target>           <note from="MultilingualBuild" annotates="source" priority="2">TextAvgDistance</note>         </trans-unit>         <trans-unit id="DetectedBeaconPageTextCount" translate="yes" xml:space="preserve">           <source>Count</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">カウント</target>           <note from="MultilingualBuild" annotates="source" priority="2">TextCount</note>         </trans-unit>         <trans-unit id="DetectedBeaconPageTextElapsedTime" translate="yes" xml:space="preserve">           <source>ElapsedTime</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">経過時間</target>           <note from="MultilingualBuild" annotates="source" priority="2">TextElapsedTime</note>         </trans-unit>         <trans-unit id="DetectedBeaconPageTextLastTime" translate="yes" xml:space="preserve">           <source>LastTime</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">ラストタイム</target>           <note from="MultilingualBuild" annotates="source" priority="2">TextLastTime</note>         </trans-unit>         <trans-unit id="DetectedBeaconPageTextMajorNo" translate="yes" xml:space="preserve">           <source>MajorNo</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">メジャーなし</target>           <note from="MultilingualBuild" annotates="source" priority="2">MajorNo</note>         </trans-unit>         <trans-unit id="DetectedBeaconPageTextMinorNo" translate="yes" xml:space="preserve">           <source>MinorNo</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">マイナーなし</target>           <note from="MultilingualBuild" annotates="source" priority="2">MinorNo</note>         </trans-unit>         <trans-unit id="UrlContributor" translate="yes" xml:space="preserve">           <source>https://covid19radar.z11.web.core.windows.net/en/contributor.html</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">https://covid19radar.z11.web.core.windows.net/en/contributor.html</target>           <note from="MultilingualBuild" annotates="source" priority="2">Url Contributor</note>         </trans-unit>         <trans-unit id="UrlUpdate" translate="yes" xml:space="preserve">           <source>https://covid19radar.z11.web.core.windows.net/en/update.html</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">https://covid19radar.z11.web.core.windows.net/en/update.html</target>           <note from="MultilingualBuild" annotates="source" priority="2">Update</note>         </trans-unit>         <trans-unit id="TitleHeadsup" translate="yes" xml:space="preserve">           <source>Heads up</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">ヘッズアップ</target>           <note from="MultilingualBuild" annotates="source" priority="2">Heads up</note>         </trans-unit>         <trans-unit id="UrlHeadsup" translate="yes" xml:space="preserve">           <source>https://covid19radar.z11.web.core.windows.net/en/qna.html</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">https://covid19radar.z11.web.core.windows.net/en/qna.html</target>           <note from="MultilingualBuild" annotates="source" priority="2">If contacted , headsup and Correct coping method and contact information Try to be calm.</note>         </trans-unit>         <trans-unit id="DescriptionPageTitleTextStep1" translate="yes" xml:space="preserve">           <source>Installing an App</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">アプリのインストール</target>           <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 1 title</note>         </trans-unit>         <trans-unit id="DescriptionPageTitleTextStep2" translate="yes" xml:space="preserve">           <source>Recording Close Contact</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">密接な連絡先の記録</target>           <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 2 title</note>         </trans-unit>         <trans-unit id="DescriptionPageTitleTextStep3" translate="yes" xml:space="preserve">           <source>If you are diagnosed COVID19 positive</source>           <target state="translated" state-qualifier="mt-suggestion">COVID-19陽性と診断されたら？</target>           <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 3 title</note>         </trans-unit>         <trans-unit id="DescriptionPageTitleTextStep4" translate="yes" xml:space="preserve">           <source>Requirements to use this app</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">このアプリを使用するための要件</target>           <note from="MultilingualBuild" annotates="source" priority="2">How it works page step 4 title</note>         </trans-unit>         <trans-unit id="TitleUserSettings" translate="yes" xml:space="preserve">           <source>Status Settings</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">ステータス設定</target>           <note from="MultilingualBuild" annotates="source" priority="2">Status Settings page title</note>         </trans-unit>         <trans-unit id="TitileUserStatusSettings" translate="yes" xml:space="preserve">           <source>Status Settings</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">ステータス設定</target>           <note from="MultilingualBuild" annotates="source" priority="2">User Status Page Title</note>         </trans-unit>         <trans-unit id="ButtonSave" translate="yes" xml:space="preserve">           <source>Save</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">保存</target>           <note from="MultilingualBuild" annotates="source" priority="2">Button Save</note>         </trans-unit>         <trans-unit id="UserStatusPageTextStatusSettingsDescription" translate="yes" xml:space="preserve">           <source>If you received a positive diagnosis, please enter your mobile number and update your status to protect your loved ones.</source>           <target state="translated" state-qualifier="mt-suggestion">陽性の診断結果を受けた場合は、携帯電話番号を入力し、あなたの愛する人を保護するためにあなたのステータスを更新してください。</target>           <note from="MultilingualBuild" annotates="source" priority="2">User Status Page description</note>         </trans-unit>         <trans-unit id="UserStatusPageTextStatusSettingsPickerTitle" translate="yes" xml:space="preserve">           <source>Tap to change state</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">タップして状態を変更する</target>           <note from="MultilingualBuild" annotates="source" priority="2">User Status Page Status Change</note>         </trans-unit>         <trans-unit id="DialogNetworkConnectionError" translate="yes" xml:space="preserve">           <source>Please check your network connection.</source>           <target state="translated">ネットワーク接続を確認してください。</target>           <note from="MultilingualBuild" annotates="source" priority="2">Dialog message for Network connection error</note>         </trans-unit>         <trans-unit id="DialogButtonOk" translate="yes" xml:space="preserve">           <source>OK</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">オーケー</target>           <note from="MultilingualBuild" annotates="source" priority="2">OK</note>         </trans-unit>         <trans-unit id="ButtonEnable" translate="yes" xml:space="preserve">           <source>Enable</source>           <target state="translated" state-qualifier="tm-suggestion">有効にする</target>           <note from="MultilingualBuild" annotates="source" priority="2">Enable Button</note>         </trans-unit>         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">           <source>NotNow</source>           <target state="translated" state-qualifier="mt-suggestion">あとで設定する</target>           <note from="MultilingualBuild" annotates="source" priority="2">NotNow Button</note>         </trans-unit>         <trans-unit id="InitSettingPageTextExposureNotificationDescription" translate="yes" xml:space="preserve">           <source>This app uses Exposure Notification / Bluetooth signals to determine if you are near another contact tracing app user.  Select 'Always Allow' to set up Bluetooth.</source>           <target state="translated" state-qualifier="mt-suggestion">このアプリは、Exposure Notification と Bluetooth を使用して、他のアプリのユーザーの近くにいるかどうか判断します。 Bluetooth を設定するには、[常に許可] を選択します。</target>           <note from="MultilingualBuild" annotates="source" priority="2">Device access page Allow Exposure Notification / Bluetooth description</note>         </trans-unit>         <trans-unit id="InitSettingPageTextExposureNotification" translate="yes" xml:space="preserve">           <source>Allow Exposure Notification / Bluetooth</source>           <target state="translated" state-qualifier="mt-suggestion">Exposure Notification と Bluetooth の許可</target>           <note from="MultilingualBuild" annotates="source" priority="2">Device access page Allow Exposure Notification / Bluetooth title</note>         </trans-unit>         <trans-unit id="MainContributors" translate="yes" xml:space="preserve">           <source>Contributors</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">貢献</target>           <note from="MultilingualBuild" annotates="source" priority="2">Tab Contributors</note>         </trans-unit>         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">           <source>Exposures</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">エクスポー ジャー</target>           <note from="MultilingualBuild" annotates="source" priority="2">Tab Button</note>         </trans-unit>         <trans-unit id="MainHome" translate="yes" xml:space="preserve">           <source>Home</source>           <target state="translated" state-qualifier="tm-suggestion">ホーム</target>           <note from="MultilingualBuild" annotates="source" priority="2">Tab Home</note>         </trans-unit>         <trans-unit id="MainLicense" translate="yes" xml:space="preserve">           <source>License</source>           <target state="translated" state-qualifier="tm-suggestion">ライセンスについて</target>           <note from="MultilingualBuild" annotates="source" priority="2">Tab License</note>         </trans-unit>         <trans-unit id="MainNotifyOther" translate="yes" xml:space="preserve">           <source>Notify</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">通知</target>           <note from="MultilingualBuild" annotates="source" priority="2">Tab Notify</note>         </trans-unit>         <trans-unit id="MainUpdateInfo" translate="yes" xml:space="preserve">           <source>Update</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">更新プログラム</target>           <note from="MultilingualBuild" annotates="source" priority="2">Tab Button</note>         </trans-unit>         <trans-unit id="TitleExposures" translate="yes" xml:space="preserve">           <source>Exposures</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">エクスポー ジャー</target>           <note from="MultilingualBuild" annotates="source" priority="2">Exposures Page</note>         </trans-unit>         <trans-unit id="NotifyOthersLearnMoreUrl" translate="yes" xml:space="preserve">           <source>https://microsoft.com/</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">https://microsoft.com/</target>           <note from="MultilingualBuild" annotates="source" priority="2">Health care jurisdiction page</note>         </trans-unit>         <trans-unit id="MainTutorial" translate="yes" xml:space="preserve">           <source>Manual</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">手動</target>           <note from="MultilingualBuild" annotates="source" priority="2">Tab How to use</note>         </trans-unit>         <trans-unit id="HomePageUpdateInfomation" translate="yes" xml:space="preserve">           <source>Update Infomation</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">情報の更新</target>           <note from="MultilingualBuild" annotates="source" priority="2">Home Page Update Infomation text</note>         </trans-unit>         <trans-unit id="HomeEnableNotification" translate="yes" xml:space="preserve">           <source>Enable Notification</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">通知を有効にする</target>           <note from="MultilingualBuild" annotates="source" priority="2">Home Setting Enable Notification</note>         </trans-unit>         <trans-unit id="ExposuresPageNoExposures" translate="yes" xml:space="preserve">           <source>No known exposures</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">既知の露出はありません</target>           <note from="MultilingualBuild" annotates="source" priority="2">If not found exposures data</note>         </trans-unit>         <trans-unit id="ExposuresPageNoExposuresInfo" translate="yes" xml:space="preserve">           <source>You will be notified if you have been exposed to someone who reported a positive COVID-19 result.</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">COVID-19の肯定的な結果を報告した人に公開された場合は、通知されます。</target>           <note from="MultilingualBuild" annotates="source" priority="2">exposures comment</note>         </trans-unit>         <trans-unit id="NofityPageButtonSharePositive" translate="yes" xml:space="preserve">           <source>Share A Positive Diagnosis</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">肯定的な診断を共有する</target>         </trans-unit>         <trans-unit id="NofityPageShareDiag" translate="yes" xml:space="preserve">           <source>Share A Positive Diagnosis</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">肯定的な診断を共有する</target>           <note from="MultilingualBuild" annotates="source" priority="2">Notify Page Share Diag</note>         </trans-unit>         <trans-unit id="NofityPageShareYourCase" translate="yes" xml:space="preserve">           <source>If you tested positive for the virus that causes COVID-19, you can choose to share your diagnosis.  This will help others in your community contain the spread of the virus.</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">COVID-19の原因となるウイルスの陽性をテストした場合は、診断を共有することを選択できます。 これは、あなたのコミュニティの他の人がウイルスの拡散を含むのに役立ちます.</target>           <note from="MultilingualBuild" annotates="source" priority="2">NofityPageShareYourCase</note>         </trans-unit>         <trans-unit id="NotifyPageLearnMore" translate="yes" xml:space="preserve">           <source>Learn more</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">詳細</target>           <note from="MultilingualBuild" annotates="source" priority="2">Notify Page Learn more text</note>         </trans-unit>         <trans-unit id="NotifyOtherPageTextStatusSettingsSubtitle" translate="yes" xml:space="preserve">           <source>If you received a positive diagnosis</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">肯定的な診断を受けた場合</target>           <note from="MultilingualBuild" annotates="source" priority="2">User Status Page subtitle</note>         </trans-unit>         <trans-unit id="NotifyOtherPageCodePlaceholder" translate="yes" xml:space="preserve">           <source>Please enter the Diagnosis Identifier</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">診断識別子を入力してください</target>           <note from="MultilingualBuild" annotates="source" priority="2">Notify Other Page Code Input</note>         </trans-unit>         <trans-unit id="TitileSharePositiveDiagnosis" translate="yes" xml:space="preserve">           <source>Share a Positive Diagnosis</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">肯定的な診断を共有する</target>         </trans-unit>         <trans-unit id="SharePositiveDiagDateText" translate="yes" xml:space="preserve">           <source>The test date helps the app know when you may have been contagious and notify the right people of potential exposure.</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">テスト日は、あなたが伝染した可能性があるときにアプリを知り、潜在的な暴露を適切な人々に通知するのに役立ちます。</target>         </trans-unit>         <trans-unit id="SharePositiveEntryCodeText" translate="yes" xml:space="preserve">           <source>Only those who have been exposed will receive a notification.</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">公開されたユーザーのみが通知を受け取ります。</target>         </trans-unit>         <trans-unit id="SharePositiveEntryCodeText2" translate="yes" xml:space="preserve">           <source>The unique test identifier that came with your COVID-19 test must be used to verify your positive test result.</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">COVID-19 テストに付属の一意のテスト ID を使用して、陽性のテスト結果を検証する必要があります。</target>         </trans-unit>         <trans-unit id="SharePositiveSubmitAndVerify" translate="yes" xml:space="preserve">           <source>Verify and Share</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">確認と共有</target>           <note from="MultilingualBuild" annotates="source" priority="2">Verify and Share</note>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageDiagExceptionText" translate="yes" xml:space="preserve">           <source>Please try again later.</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">後でもう一度試してください。</target>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageDiagExceptionTitle" translate="yes" xml:space="preserve">           <source>Failed</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">失敗</target>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageDiagSubmittedText" translate="yes" xml:space="preserve">           <source>Diagnosis Submitted</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">診断提出</target>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageDiagSubmittedTitle" translate="yes" xml:space="preserve">           <source>Complete</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">完了しました</target>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageDiagUidIsEmptyText" translate="yes" xml:space="preserve">           <source>Please provide a Diagnosis Identifier</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">診断識別子を指定してください</target>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageDiagUidIsEmptyTitle" translate="yes" xml:space="preserve">           <source>Diagnosis Identifier Required</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">診断識別子が必要です</target>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageDialogButton" translate="yes" xml:space="preserve">           <source>OK</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">オーケー</target>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageNotEnabledENDialogText" translate="yes" xml:space="preserve">           <source>Please enable Exposure Notifications before submitting a diagnosis.</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">診断を送信する前に露出通知を有効にしてください。</target>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageNotEnabledENDialogTitle" translate="yes" xml:space="preserve">           <source>Exposure Notifications Disabled</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">露出通知が無効</target>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageSubmittingDialog" translate="yes" xml:space="preserve">           <source>Submitting Diagnosis...</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">診断を提出します。</target>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageVerifyDialog" translate="yes" xml:space="preserve">           <source>Verifying Diagnosis...</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">診断を確認しています。</target>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageVerifyFailedDialogText" translate="yes" xml:space="preserve">           <source>Your diagnosis cannot be verified at this time to be submitted.</source>           <target state="needs-review-translation" state-qualifier="mt-suggestion">現時点では、診断を確認できません。</target>         </trans-unit>         <trans-unit id="SharePositiveDiagnosisPageVerifyFailedDialogTitle" translate="yes" xml:space="preserve">           <source>Verification Failed</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">検証に失敗しました</target>         </trans-unit>         <trans-unit id="ButtonPositiveSubmit" translate="yes" xml:space="preserve">           <source>Submit</source>           <target state="needs-review-translation" state-qualifier="tm-suggestion">提出</target>         </trans-unit>         <trans-unit id="DescriptionPageTextStep1Description2" translate="yes" xml:space="preserve">           <source>SampleText</source>           <target state="new">SampleText</target>         </trans-unit>         <trans-unit id="DescriptionPageTextStep2Description2" translate="yes" xml:space="preserve">           <source>SampleText</source>           <target state="new">SampleText</target>         </trans-unit>       </group>     </body>   </file> </xliff>


### PR DESCRIPTION
- Fix Japanese Translation based on Prototype UI: FIX_COVID19Radar
- Fix "COVID-19" coronavirus name