### PR TITLE
Fix minSdkVersion 23

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Properties/AndroidManifest.xml
+++ b/Covid19Radar/Covid19Radar.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="jp.go.mhlw.covid19radar" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
+	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="29" />
 	<application android:label="COVID-19Radar" android:icon="@mipmap/ic_launcher">
 		<receiver android:name=".nearby.ExposureNotificationBroadcastReceiver" android:permission="com.google.android.gms.nearby.exposurenotification.EXPOSURE_CALLBACK" android:exported="true">
 			<intent-filter>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix minSdkVersion 23
Android Exposure Notification API need Android version 6.0 (API 23) or higher.
https://static.googleusercontent.com/media/www.google.com/en//covid19/exposurenotifications/pdfs/Android-Exposure-Notification-API-documentation-v1.3.2.pdf