### PR TITLE
Fix "NotNow"

### DIFF
--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.af.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.af.xlf
@@ -48,7 +48,7 @@
           <target state="translated">Goed</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="translated">Nie Nou Nie</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ar.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ar.xlf
@@ -48,7 +48,7 @@
           <target state="translated">موافق</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="translated">ليس الان</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.bg.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.bg.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ОК</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Не сега</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.bn.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.bn.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ঠিক আছে</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">এখন</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ca.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ca.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">D'acord</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.cs.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.cs.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.cy.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.cy.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Iawn</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.da.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.da.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow (NotNow)</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.de.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.de.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">[YTzsp]OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.el.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.el.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ΟΚ</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Όχι τώρα</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.en.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.en.xlf
@@ -45,8 +45,8 @@
           <target state="translated" state-qualifier="mt-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
-          <target state="translated" state-qualifier="mt-suggestion">NotNow</target>
+          <source>Not Now</source>
+          <target state="translated" state-qualifier="mt-suggestion">Not Now</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">
           <source>Exposures</source>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.es.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.es.xlf
@@ -48,7 +48,7 @@
           <target state="translated">Aceptar</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.et.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.et.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Mitte praegu.</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fa.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fa.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">تأیید</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fi.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fi.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">OK\n</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Ei nyt</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fil.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fil.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Sa ngayon</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fr.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fr.xlf
@@ -48,7 +48,7 @@
           <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="translated">Pas maintenant</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ga.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ga.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.gu.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.gu.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ઠીક</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">નોટહવે</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.he.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.he.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">אישור</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">לא עכשיו</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.hi.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.hi.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ठीक</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">नॉटअब</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.hr.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.hr.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">U redu</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Ne sada</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.hu.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.hu.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow között</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.id.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.id.xlf
@@ -48,7 +48,7 @@
           <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="translated">Tidak sekarang</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.is.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.is.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Í lagi</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Ekki</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.it.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.it.xlf
@@ -48,7 +48,7 @@
           <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="translated">Non ora</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ja.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ja.xlf
@@ -45,7 +45,7 @@
           <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="translated">あとで設定する</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.kn.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.kn.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ಸರಿ</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">ನೋಟನೌ</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ko.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ko.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">확인</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.lt.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.lt.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Gerai</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Nedabar</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.lv.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.lv.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Labi</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mg.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mg.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Tsy maninona</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mi.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mi.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ĀE</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ml.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ml.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ശരി</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">ഇപ്പോൾ നോട്ടൗട്ട്</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mr.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mr.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ठीक</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">आता नाही</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ms.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ms.xlf
@@ -48,7 +48,7 @@
           <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="translated">Bukan sekarang</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mt.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mt.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.nb.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.nb.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="mt-suggestion">ok</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow (andre er ikke noe av</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.nl.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.nl.xlf
@@ -48,7 +48,7 @@
           <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="translated">Niet nu</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.pl.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.pl.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Ok</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow (Nienow)</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.pt.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.pt.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Não Agora</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ro.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ro.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Nu acum.</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ru.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ru.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ОК</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Не сейчас</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sk.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sk.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sl.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sl.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">V redu</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Ne zdaj</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sr-Cyrl.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sr-Cyrl.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">У реду</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Не сада</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sr-Latn.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sr-Latn.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">U redu</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Ne sada</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sv.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sv.xlf
@@ -55,7 +55,7 @@
         </trans-unit>
         <!--Context?-->
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow (NotNow)</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sw.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sw.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Sawa</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">Dokezi sasa</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ta.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ta.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">சரி</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">இப்போது இல்லை</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.te.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.te.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">సరే</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">నోట్నౌ</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.th.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.th.xlf
@@ -48,7 +48,7 @@
           <target state="translated">ตกลง</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="translated">ไม่ใช่ตอนนี้</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.tr.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.tr.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Tamam</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.uk.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.uk.xlf
@@ -48,8 +48,8 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ОК</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">NotNow</target>
+          <source>Not Now</source>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">Not Now</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">
           <source>Exposures</source>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ur.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ur.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ٹھیک ہے</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">نوٹناوو</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.vi.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.vi.xlf
@@ -48,7 +48,7 @@
           <target state="needs-review-translation" state-qualifier="tm-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="final" state-qualifier="mt-suggestion">Không phải bây giờ</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.zh-Hans.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.zh-Hans.xlf
@@ -45,7 +45,7 @@
           <target state="translated">确定</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="translated">暂时不</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.zh-Hant.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.zh-Hant.xlf
@@ -46,7 +46,7 @@
           <target state="translated">確定</target>
         </trans-unit>
         <trans-unit id="ButtonNotNow" translate="yes" xml:space="preserve">
-          <source>NotNow</source>
+          <source>Not Now</source>
           <target state="needs-review-translation" state-qualifier="mt-suggestion">現在不</target>
         </trans-unit>
         <trans-unit id="MainExposures" translate="yes" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
@@ -115,7 +115,7 @@ namespace Covid19Radar.Resources {
         }
         
         /// <summary>
-        ///   NotNow に類似しているローカライズされた文字列を検索します。
+        ///   Not Now に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string ButtonNotNow {
             get {

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.en.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.en.resx
@@ -43,7 +43,7 @@
     <value>OK</value>
   </data>
   <data name="ButtonNotNow" xml:space="preserve">
-    <value>NotNow</value>
+    <value>Not Now</value>
   </data>
   <data name="MainExposures" xml:space="preserve">
     <value>Exposures</value>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.resx
@@ -156,7 +156,7 @@
     <comment>Dialog message for Network connection error</comment>
   </data>
   <data name="ButtonNotNow" xml:space="preserve">
-    <value>NotNow</value>
+    <value>Not Now</value>
   </data>
   <data name="MainExposures" xml:space="preserve">
     <value>Exposures</value>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.uk.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.uk.resx
@@ -43,7 +43,7 @@
     <value>ОК</value>
   </data>
   <data name="ButtonNotNow" xml:space="preserve">
-    <value>NotNow</value>
+    <value>Not Now</value>
   </data>
   <data name="MainExposures" xml:space="preserve">
     <value>Впливів</value>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix "NotNow" to "Not Now" ( insert a space ) .
* I think the original English text "NotNow" is confusing the translation.

|File|Translation|Google Translate "not now"|
|-|-|-|
|Covid19Radar.da.xlf|NotNow (NotNow)|ikke nu|
|Covid19Radar.pl.xlf|NotNow (Nienow)|nie teraz|
|Covid19Radar.sv.xlf|NotNow (NotNow)|inte nu|

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Multilingual Support
```

## How to Test

## What to Check
Verify that the following are valid
*  I'm sorry I don't know about the machine translation system of the project. Please try to update the machine translation of `ButtonNotNow` .

> Otherwise, it may be overwritten by machine translation.

https://github.com/Covid-19Radar/Covid19Radar/blob/master/HOW_TO_TRANSLATE_CONTRIBUTE.md#notes-on-translation

## Other Information
<!-- Add any other helpful information that may be needed here. -->