### PR TITLE
Improves English translation of consent submission screen

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,6 +58,7 @@
 - Mohamed BOUZIDI(github actions)
 - Yutaro Iino (Documentation)
 - Kohei Ikeda(Documentation)
+- Daniel Kastl (Translation)
 
 # Beta Testers
 - Nagahata Kenji

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.en.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.en.xlf
@@ -649,27 +649,27 @@
         </trans-unit>
         <trans-unit id="SubmitConsentPageDescription1" translate="yes" xml:space="preserve">
           <source>The processing number will be notified to your mobile phone number or e-mail address registered in the new coronavirus infectious disease information and management system (hereinafter "management system").</source>
-          <target state="translated">The processing number will be notified to your mobile phone number or e-mail address registered in the new coronavirus infectious disease information and management system (hereinafter "management system").</target>
+          <target state="translated">The processing number will be sent to your mobile phone number or email address registered with the new coronavirus infectious disease information and management system (hereinafter "management system").</target>
           <note from="MultilingualBuild" annotates="source" priority="2">新型コロナウイルス感染症等情報把握・管理システム（以下「管理システム」）に登録されたあなたの携帯電話番号又はメールアドレスに、処理番号が通知されます。</note>
         </trans-unit>
         <trans-unit id="SubmitConsentPageDescription2" translate="yes" xml:space="preserve">
           <source>When you enter this processing number into the terminal, the terminal will make an inquiry via the notification server to the management system as to whether the processing number has been issued to you.</source>
-          <target state="translated">When you enter this processing number into the terminal, the terminal will make an inquiry via the notification server to the management system as to whether the processing number has been issued to you.</target>
+          <target state="translated">When you enter this number into the device, the device will query the management system through the notification server to see if the number has been issued to you or not.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">あなたがこの処理番号を端末に入力することにより、端末から通知サーバーを経由して管理システムに対し、処理番号があなたに対して発行されたものか否かの照会が行われます。</note>
         </trans-unit>
         <trans-unit id="SubmitConsentPageDescription3" translate="yes" xml:space="preserve">
           <source>The management system will respond to the notification server as to whether the transaction number referred to was issued to you.</source>
-          <target state="translated">The management system will respond to the notification server as to whether the transaction number referred to was issued to you.</target>
+          <target state="translated">The management system responds to the notification server as to whether the queried processing number was issued to you or not.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">管理システムは、通知サーバーに対し、照会された処理番号があなたに対して発行されたものか否かについて回答します。</note>
         </trans-unit>
         <trans-unit id="SubmitConsentPageDescription4" translate="yes" xml:space="preserve">
           <source>If you reply that the transaction number was issued to you, other users' terminals will be provided with the daily key recorded on your terminal.</source>
-          <target state="translated">If you reply that the transaction number was issued to you, other users' terminals will be provided with the daily key recorded on your terminal.</target>
+          <target state="translated">If the response is that the processing number was issued to you, the other user's devices will be provided with the daily data that was recorded on your device.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">処理番号があなたに対して発行されたものである旨の回答が行われた場合は、他の利用者の端末に、あなたの端末に記録された日次鍵が提供されます。</note>
         </trans-unit>
         <trans-unit id="SubmitConsentPageDescription5" translate="yes" xml:space="preserve">
           <source>If you have been in contact with you within 14 days, you will know that you may have been contacted without any information that can identify you personally.</source>
-          <target state="translated">If you have been in contact with you within 14 days, you will know that you may have been contacted without any information that can identify you personally.</target>
+          <target state="translated">People who have been in contact with you within 14 days will be informed that they may have been in contact with you but without providing any personally identifiable information about you.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">14日以内にあなたと接触の状態となったことのある方は、あなた個人を識別可能な情報がない状態で、接触した可能性がある旨を知ることができます。</note>
         </trans-unit>
         <trans-unit id="SubmitConsentPageDescription6" translate="yes" xml:space="preserve">


### PR DESCRIPTION
## Purpose

The English version of the "submit consent page" is very difficult to understand at the beginning, and not understandable at all in the last paragraph. This PR tries to improve the translation based on the Japanese translation.

## Does this introduce a breaking change?

[ ] Yes
[x] No

## Pull Request Type

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: localization improvement

## Other Information

It seems that English was used as the `source` language in the localization process, but lots of strings were machine translated from Japanese. I'm wondering if the localization to other languages was done correctly based on the English source.