### PR TITLE
Update HelpMenuPageViewModel.cs

### DIFF
--- a/Covid19Radar/Covid19Radar/ViewModels/HelpPage/HelpMenuPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HelpPage/HelpMenuPageViewModel.cs
@@ -58,6 +58,7 @@ namespace Covid19Radar.ViewModels
         async void Navigate()
         {
             await NavigationService.NavigateAsync(SelectedMenuItem.PageName);
+            SelectedMenuItem = null;
             return;
         }
     }


### PR DESCRIPTION
## Purpose
Reset ListView.SelectedItem after selected.

各ヘルプページから戻った後、アイテムが選択されたままなのは不自然な挙動だと思います。  
色の関係で矢印が見えなくなるのも混乱します。

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe:
```
Small UI update.

## How to Test
Run and see.

## What to Check
微修正なのでテストも実行もしていません。

## Other Information
[メニューページ](https://github.com/Covid-19Radar/Covid19Radar/blob/master/Covid19Radar/Covid19Radar/Views/MenuPage.xaml)も同様の仕様で、遷移後もListViewが選択されたままになっています。
表示中のページが選択されているわけですから、こちらに比べれば直感的ではあるので今回修正対象に入れていません。
ですが、色の関係で選択中はアイコンが見えないというのは問題点です。

選択されたものをSelectedItemで取得するというのはListViewとしては標準的な仕様なので修正しないのも選択肢ではあります。
ただ、選択後リセットする方が大抵は自然な挙動になります。
<!-- Add any other helpful information that may be needed here. -->