### PR TITLE
iOS Bundle SigningOption to 'Automatic'

### DIFF
--- a/Covid19Radar/Covid19Radar.iOS/Covid19Radar.iOS.csproj
+++ b/Covid19Radar/Covid19Radar.iOS/Covid19Radar.iOS.csproj
@@ -27,8 +27,7 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
-    <CodesignKey>Apple Development: Hirose Kazumi (B5NUWQDLW4)</CodesignKey>
-    <CodesignProvision>Covid19radar</CodesignProvision>
+    <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <LangVersion>latest</LangVersion>
     <MtouchExtraArgs>--optimize=experimental-xforms-product-type --weak-framework=ExposureNotification</MtouchExtraArgs>
@@ -59,12 +58,11 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <MtouchArch>ARM64</MtouchArch>
-    <CodesignKey>Apple Development: Hirose Kazumi (B5NUWQDLW4)</CodesignKey>
+    <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <IOSDebugOverWiFi>true</IOSDebugOverWiFi>
     <IOSDebugOverWiFi>true</IOSDebugOverWiFi>
-    <CodesignProvision>Covid19radar</CodesignProvision>
     <MtouchExtraArgs>--optimize=experimental-xforms-product-type --weak-framework=ExposureNotification</MtouchExtraArgs>
     <MtouchSdkVersion>
     </MtouchSdkVersion>


### PR DESCRIPTION
## Purpose
This change allows developers to build with the signature and Provisioning Profile set on their Mac.

![image](https://user-images.githubusercontent.com/39830/85152610-6bf48880-b27f-11ea-9c4e-9735813a60b2.png)

>When set to Automatic, Visual Studio for Mac will select the identity and profile based on the Bundle Identifier in Info.plist. https://docs.microsoft.com/en-us/xamarin/ios/get-started/installation/device-provisioning/manual-provisioning?tabs=macos

build was successful in my environment.
<img src="https://user-images.githubusercontent.com/39830/85152670-7c0c6800-b27f-11ea-9a19-2d846d1e23fd.png" height=500>

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

Since this pull request is for the purpose of building the development version, Covid19Radar. The configuration, Release, AppStore, etc. except for iOS(Debug) will not be changed.

## Pull Request Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Build Covid19Radar.iOS(Debug) in Visual Studio for Mac.

## What to Check
Check to see if the changes will not be detrimental to App Distribution.