### PR TITLE
fix a crash on StopExposureNotification()

### DIFF
--- a/Covid19Radar/Covid19Radar/Services/ExposureNotificationService.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureNotificationService.cs
@@ -180,7 +180,10 @@ namespace Covid19Radar.Services
 
         public async Task<bool> StopExposureNotification()
         {
-            await ExposureNotification.StopAsync();
+            if (await Xamarin.ExposureNotifications.ExposureNotification.IsEnabledAsync())
+            {
+                await ExposureNotification.StopAsync();
+            }
             return true;
         }
 


### PR DESCRIPTION
## Purpose
App crashes #450 の修正として提案する変更です。
ExposureNotification が無効な時に`ExposureNotification.StopAsync()` を呼び出さないようにしました。

## Does this introduce a breaking change?
```
[x] Yes
[ ] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
1. iOSの設定で COVID-19 Exposure Notifications をオフにしてアプリを起動
2. UserDataChanged 発生
3. クラッシュ?

<img src="https://user-images.githubusercontent.com/39830/85190774-db04c800-b2e5-11ea-9c9f-63ac3c221fb6.png" height=500>

## What to Check
実際のExposure Notifications APIの試験ができないのでこれで修正ができているのかどうか