### PR TITLE
[Fix] "0 Days" shown only "Days" and i18n resources

### DIFF
--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.af.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.af.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dae</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ar.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ar.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">أيام</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.bg.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.bg.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Дни</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.bn.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.bn.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">দিনগুলো</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ca.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ca.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dies</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.cs.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.cs.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dny</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.cy.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.cy.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Diwrnod</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.da.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.da.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">DAGE</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.de.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.de.xlf
@@ -760,7 +760,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">TAGE</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.el.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.el.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ΗΜΕΡΕΣ</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.es.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.es.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">días</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.et.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.et.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">päeva</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fa.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fa.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">روز</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fi.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fi.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">päivää</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fil.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fil.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">(na) Araw</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fr.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.fr.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">JOURS</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ga.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ga.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Lá</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.gu.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.gu.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">દિવસ</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.he.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.he.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ימים</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.hi.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.hi.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">दिन</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.hr.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.hr.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">DANI</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.hu.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.hu.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">nap</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.id.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.id.xlf
@@ -760,7 +760,7 @@ Catatan: kode kontak akan berubah secara berkala untuk melindungi privasi anda.<
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Hari</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.is.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.is.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dagar</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.it.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.it.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Giorni</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ja.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ja.xlf
@@ -758,7 +758,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="translated">日間</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.kn.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.kn.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ದಿನಗಳು</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ko.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ko.xlf
@@ -762,7 +762,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">일</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.lt.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.lt.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dienos</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.lv.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.lv.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dienas</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mi.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mi.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ngā rā</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ml.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ml.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ദിവസം</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mr.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mr.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">दिवस</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ms.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ms.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">hari</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mt.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.mt.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Jiem</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.nb.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.nb.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dager</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.nl.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.nl.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">DAGEN</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.pl.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.pl.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dni</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.pt.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.pt.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dias</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ro.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ro.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Zile</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ru.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ru.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">дн.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sk.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sk.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dni</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sl.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sl.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dni</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sr-Cyrl.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sr-Cyrl.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Дани</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sr-Latn.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sr-Latn.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dani</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sv.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sv.xlf
@@ -784,7 +784,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Dagar</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sw.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.sw.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Siku</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ta.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ta.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">நாட்கள்</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.te.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.te.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">రోజులు</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.th.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.th.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">วัน</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.tr.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.tr.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">gün</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.uk.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.uk.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">дн.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ur.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ur.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">ايام</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.vi.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.vi.xlf
@@ -777,7 +777,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ngày</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.zh-Hans.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.zh-Hans.xlf
@@ -758,7 +758,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="translated">天</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.zh-Hant.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.zh-Hant.xlf
@@ -775,7 +775,7 @@
         </trans-unit>
         <trans-unit id="HomePagePastDays" translate="yes" xml:space="preserve">
           <source>Days</source>
-          <target state="new">Days</target>
+          <target state="translated">天</target>
           <note from="MultilingualBuild" annotates="source" priority="2">X日間</note>
         </trans-unit>
       </group>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.af.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.af.resx
@@ -607,4 +607,8 @@
     <value>Navrae oor kontakbevestiging-toepassing</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dae</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ar.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ar.resx
@@ -607,4 +607,8 @@
     <value>استفسارات حول تطبيق تأكيد الاتصال</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>أيام</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.bg.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.bg.resx
@@ -607,4 +607,8 @@
     <value>Запитвания за приложението за потвърждение на контакт</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Дни</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.bn.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.bn.resx
@@ -607,4 +607,8 @@
     <value>কন্ট্যাক্ট কনফার্মেশন অ্যাপ সম্পর্কে অনুসন্ধান</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>দিনগুলো</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ca.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ca.resx
@@ -607,4 +607,8 @@
     <value>Consultes sobre l'aplicació de confirmació de contacte</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dies</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.cs.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.cs.resx
@@ -607,4 +607,8 @@
     <value>Dotazy týkající se aplikace pro potvrzení kontaktu</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dny</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.cy.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.cy.resx
@@ -607,4 +607,8 @@
     <value>Ymholiadau am gadarnhad cyswllt</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Diwrnod</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.da.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.da.resx
@@ -607,4 +607,8 @@
     <value>Forespørgsler om app til bekræftelse af kontakt</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>DAGE</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.de.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.de.resx
@@ -607,4 +607,8 @@
     <value>Anfragen zur Kontaktbestätigungs-App</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>TAGE</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.el.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.el.resx
@@ -607,4 +607,8 @@
     <value>Ερωτήσεις σχετικά με την εφαρμογή επιβεβαίωσης επαφών</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>ΗΜΕΡΕΣ</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.es.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.es.resx
@@ -607,4 +607,8 @@
     <value>Consultas sobre la aplicación de confirmación de contacto</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>días</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.et.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.et.resx
@@ -607,4 +607,8 @@
     <value>Päringud kontakti kinnitusrakenduse kohta</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>päeva</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.fa.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.fa.resx
@@ -607,4 +607,8 @@
     <value>سوالات مربوط به برنامه تأیید تماس</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>روز</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.fi.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.fi.resx
@@ -607,4 +607,8 @@
     <value>Yhteyshenkilön vahvistussovellusta koskevat kyselyt</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>päivää</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.fil.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.fil.resx
@@ -607,4 +607,8 @@
     <value>Mga tanong tungkol sa contact confirmation app</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>(na) Araw</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.fr.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.fr.resx
@@ -607,4 +607,8 @@
     <value>Demandes de renseignements sur l’application de confirmation de contact</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>JOURS</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ga.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ga.resx
@@ -607,4 +607,8 @@
     <value>Fiosrúcháin faoi fheidhmchlár deimhnithe teagmhála</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Lá</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.gu.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.gu.resx
@@ -607,4 +607,8 @@
     <value>સંપર્ક પુષ્ટિ એપ્લિકેશન વિશે પૂછપરછ</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>દિવસ</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.he.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.he.resx
@@ -607,4 +607,8 @@
     <value>שאילתות אודות יישום אישור של איש קשר</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>ימים</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.hi.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.hi.resx
@@ -607,4 +607,8 @@
     <value>संपर्क पुष्टि ऐप के बारे में पूछताछ</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>दिन</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.hr.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.hr.resx
@@ -607,4 +607,8 @@
     <value>Upiti o aplikaciji za potvrdu kontakta</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>DANI</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.hu.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.hu.resx
@@ -607,4 +607,8 @@
     <value>A kapcsolattartó-megerősítő alkalmazással kapcsolatos lekérdezések</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>nap</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.id.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.id.resx
@@ -609,4 +609,8 @@ Catatan: kode kontak akan berubah secara berkala untuk melindungi privasi anda.<
     <value>Pertanyaan tentang aplikasi ini.</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Hari</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.is.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.is.resx
@@ -607,4 +607,8 @@
     <value>Fyrirspurnir um staðfestingarforrit tengiliðar</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dagar</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.it.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.it.resx
@@ -607,4 +607,8 @@
     <value>Richieste di informazioni sull'app di conferma dei contatti</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Giorni</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -607,4 +607,8 @@
     <value>接触確認アプリに関するお問い合わせ</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>日間</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.kn.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.kn.resx
@@ -607,4 +607,8 @@
     <value>ಸಂಪರ್ಕ ದೃಢೀಕರಣ ಅಪ್ಲಿಬಗ್ಗೆ ವಿಚಾರಣೆಗಳು</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>ದಿನಗಳು</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ko.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ko.resx
@@ -607,4 +607,8 @@
     <value>연락처 확인 앱에 대한 문의</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>일</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.lt.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.lt.resx
@@ -607,4 +607,8 @@
     <value>Užklausos apie kontaktinę patvirtinimo programą</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dienos</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.lv.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.lv.resx
@@ -607,4 +607,8 @@
     <value>Uzziņas par kontaktu apstiprinājuma lietotni</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dienas</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.mi.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.mi.resx
@@ -607,4 +607,8 @@
     <value>Inquiries mō te taupānga whakaū hoapā</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Ngā rā</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ml.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ml.resx
@@ -607,4 +607,8 @@
     <value>കോൺടാക്റ്റ് സ്ഥിരീകരണ ആപ്പിനെക്കുറിച്ചുള്ള അന്വേഷണങ്ങൾ</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>ദിവസം</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.mr.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.mr.resx
@@ -607,4 +607,8 @@
     <value>संपर्क पुष्टी अॅपबद्दल चौकशी</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>दिवस</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ms.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ms.resx
@@ -607,4 +607,8 @@
     <value>Pertanyaan mengenai aplikasi pengesahan kenalan</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>hari</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.mt.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.mt.resx
@@ -607,4 +607,8 @@
     <value>Mistoqsijiet dwar l-applikazzjoni tal-konferma tal-kuntatt</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Jiem</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.nb.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.nb.resx
@@ -607,4 +607,8 @@
     <value>Forespørsler om kontaktbekreftelsesapp</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dager</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.nl.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.nl.resx
@@ -607,4 +607,8 @@
     <value>Vragen over de contactbevestigingsapp</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>DAGEN</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.pl.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.pl.resx
@@ -607,4 +607,8 @@
     <value>Zapytania dotyczące aplikacji potwierdzającej kontakt</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dni</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.pt.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.pt.resx
@@ -607,4 +607,8 @@
     <value>Consultas sobre o aplicativo de confirmação de contatos</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dias</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ro.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ro.resx
@@ -607,4 +607,8 @@
     <value>Întrebări despre aplicația de confirmare a contactului</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Zile</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ru.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ru.resx
@@ -607,4 +607,8 @@
     <value>Запросы о приложении подтверждения контактов</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>дн.</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.sk.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.sk.resx
@@ -607,4 +607,8 @@
     <value>Otázky týkajúce sa aplikácie na potvrdenie kontaktu</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dni</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.sl.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.sl.resx
@@ -607,4 +607,8 @@
     <value>Poizvedbe o aplikaciji za potrditev stika</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dni</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.sr-Cyrl.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.sr-Cyrl.resx
@@ -607,4 +607,8 @@
     <value>Питања о апликацији "потврда контакта"</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Дани</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.sr-Latn.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.sr-Latn.resx
@@ -607,4 +607,8 @@
     <value>Pitanja o aplikaciji "potvrda kontakta"</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dani</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.sv.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.sv.resx
@@ -607,4 +607,8 @@
     <value>Frågor om kontaktbekräftelseapp</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Dagar</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.sw.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.sw.resx
@@ -607,4 +607,8 @@
     <value>Maswali kuhusu programu ya uthibitisho wa kuwasiliana</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Siku</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ta.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ta.resx
@@ -607,4 +607,8 @@
     <value>தொடர்பு உறுதிப்படுத்தல் பயன்பாட்டை ப்பற்றிய விசாரணைகள்</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>நாட்கள்</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.te.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.te.resx
@@ -607,4 +607,8 @@
     <value>కాంటాక్ట్ ధృవీకరణ యాప్ గురించి విచారణలు</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>రోజులు</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.th.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.th.resx
@@ -607,4 +607,8 @@
     <value>สอบถามเกี่ยวกับแอปการยืนยันผู้ติดต่อ</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>วัน</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.tr.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.tr.resx
@@ -607,4 +607,8 @@
     <value>İletişim onay uygulaması hakkında sorular</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>gün</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.uk.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.uk.resx
@@ -607,4 +607,8 @@
     <value>Запити щодо додатка підтвердження контакту</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>дн.</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ur.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ur.resx
@@ -607,4 +607,8 @@
     <value>رابطہ تصدیق ایپ کے بارے میں انکوائری</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>ايام</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.vi.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.vi.resx
@@ -607,4 +607,8 @@
     <value>Câu hỏi về ứng dụng xác nhận liên hệ</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>Ngày</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hans.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hans.resx
@@ -607,4 +607,8 @@
     <value>对该接触情况应用进行咨询</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>天</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hant.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hant.resx
@@ -607,4 +607,8 @@
     <value>關於此 App 的諮詢</value>
     <comment>接触確認アプリに関するお問い合わせ</comment>
   </data>
+  <data name="HomePagePastDays" xml:space="preserve">
+    <value>天</value>
+    <comment>X日間</comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -47,11 +47,7 @@ namespace Covid19Radar.ViewModels
             StartDate = userData.StartDateTime.ToLocalTime().ToString("D");
 
             TimeSpan timeSpan = DateTime.Now - userData.StartDateTime;
-            PastDate = timeSpan.Days.ToString("D");
-            if (PastDate == "0")
-            {
-                PastDate = "";
-            }
+            PastDate = timeSpan.Days.ToString();
         }
 
         public Command OnClickExposures => new Command(async () =>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/HomePage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/HomePage.xaml
@@ -36,8 +36,11 @@
                             <FormattedString>
                                 <Span Text="{Binding StartDate}" />
                                 <Span Text="{x:Static resources:AppResources.HomePageDescription0}" />
+                                <Span Text=" "/>
                                 <Span Text="{Binding PastDate}" />
+                                <Span Text=" "/>
                                 <Span Text="{x:Static resources:AppResources.HomePagePastDays}" />
+                                <Span Text=" "/>
                                 <Span Text="{x:Static resources:AppResources.HomePageDescription1}" />
                             </FormattedString>
                         </Label.FormattedText>


### PR DESCRIPTION
"Days" translate missing.
"0 Days" shown only "Days" in HomePage. 
Add space before and after "Days".

"Days" リソースが翻訳されていませんでした。
0日の時に、”0日間”と出るはずが、"日間" と出てしまう問題を修正しました。
"X days” と出す前後にスペースを追加しました。 