### PR TITLE
Unify Share links on Android and iOS.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -68,6 +68,7 @@
 - Elisa Sakamoto (Italian Translation)
 - Leo Ando (Client Android)
 - Prastyo ([Indonesian Translation](https://github.com/Covid-19Radar/Covid19Radar/commits?author=jiprastyo))
+- Kenji Matsuoka(Xamarin)
 
 # Beta Testers
 - Nagahata Kenji

--- a/Covid19Radar/Covid19Radar/AppSettings.cs
+++ b/Covid19Radar/Covid19Radar/AppSettings.cs
@@ -25,8 +25,7 @@ namespace Covid19Radar
 
             AppVersion = j.Value<string>("appVersion");
             LicenseUrl = j.Value<string>("licenseUrl");
-            AppStoreUrl = j.Value<string>("appStoreUrl");
-            GooglePlayUrl = j.Value<string>("googlePlayUrl");
+            ShareAppUrl = j.Value<string>("shareAppUrl");
             ApiUrlBase = j.Value<string>("apiUrlBase");
             ApiSecret = j.Value<string>("apiSecret");
             CdnUrlBase = j.Value<string>("cdnUrlBase");
@@ -41,8 +40,7 @@ namespace Covid19Radar
         public string LicenseUrl { get; }
         public string ApiUrlBase { get; }
         public string ApiSecret { get; }
-        public string AppStoreUrl { get; }
-        public string GooglePlayUrl { get; }
+        public string ShareAppUrl { get; }
         public string CdnUrlBase { get; }
 
 

--- a/Covid19Radar/Covid19Radar/Common/AppUtils.cs
+++ b/Covid19Radar/Covid19Radar/Common/AppUtils.cs
@@ -15,23 +15,11 @@ namespace Covid19Radar.Common
         }
         public static async void PopUpShare()
         {
-            if (Device.RuntimePlatform == Device.iOS)
+            await Share.RequestAsync(new ShareTextRequest
             {
-                await Share.RequestAsync(new ShareTextRequest
-                {
-                    Uri = AppSettings.Instance.AppStoreUrl,
-                    Title = Resources.AppResources.AppName
-                });
-            }
-            else if (Device.RuntimePlatform == Device.Android)
-            {
-                await Share.RequestAsync(new ShareTextRequest
-                {
-                    Uri = AppSettings.Instance.GooglePlayUrl,
-                    Title = Resources.AppResources.AppName
-                });
-            }
-
+                Uri = AppSettings.Instance.ShareAppUrl,
+                Title = Resources.AppResources.AppName
+            });
         }
 
     }

--- a/Covid19Radar/Covid19Radar/settings.json
+++ b/Covid19Radar/Covid19Radar/settings.json
@@ -7,7 +7,6 @@
   "androidSafetyNetApiKey": "AIzaSyDU-HjfMDUcF-rVrdGW4fJS1RAvK_L9eew",
   "cdnUrlBase": "https://covid19radar-jpn-prod.azureedge.net/",
   "licenseUrl": "https://covid19radarjpnprod.z11.web.core.windows.net/license.html",
-  "appStoreUrl": "https://itunes.apple.com/jp/app/id1516764458?mt=8",
-  "googlePlayUrl": "https://play.google.com/store/apps/details?id=jp.go.mhlw.covid19radar",
+  "shareAppUrl": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/cocoa_00138.html",
   "supportEmail": "appsupport@cov19.mhlw.go.jp"
 }


### PR DESCRIPTION
Because platform-dependent store URL is cannot be shared with users on another platform.

## Purpose
Soluved to issue 569
issue #569 に記載しましたが、リンク先をGooglePlayStoreやAppStoreのURLとすると、共有元と異なるプラットフォームのユーザーへアプリを共有することができません。
両方のストアのURLが記載されているページへリンクするほうが適切であるように思われます。

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
This code has not been tested.
元のソースを手元でビルドすることができませんでした。テストの方法が知りたいッ