### PR TITLE
minSDKVersionが23のためRuntime Permission時の動作OSバージョンチェックは不要のため削除

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/MainActivity.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainActivity.cs
@@ -65,13 +65,13 @@ namespace Covid19Radar.Droid
 
         private void RequestPermission()
         {
-                string[] permissions = new string[] {
-                    Android.Manifest.Permission.Bluetooth,
-                    Android.Manifest.Permission.BluetoothPrivileged,
-                    Android.Manifest.Permission.BluetoothAdmin,
-                };
+            string[] permissions = new string[] {
+                Android.Manifest.Permission.Bluetooth,
+                Android.Manifest.Permission.BluetoothPrivileged,
+                Android.Manifest.Permission.BluetoothAdmin,
+            };
 
-                RequestPermissions(permissions, 0);
+            RequestPermissions(permissions, 0);
         }
 
         protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)

--- a/Covid19Radar/Covid19Radar.Android/MainActivity.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainActivity.cs
@@ -65,8 +65,6 @@ namespace Covid19Radar.Droid
 
         private void RequestPermission()
         {
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.M)
-            {
                 string[] permissions = new string[] {
                     Android.Manifest.Permission.Bluetooth,
                     Android.Manifest.Permission.BluetoothPrivileged,
@@ -74,7 +72,6 @@ namespace Covid19Radar.Droid
                 };
 
                 RequestPermissions(permissions, 0);
-            }
         }
 
         protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)


### PR DESCRIPTION
close #573 

## Purpose
AndroidのminSDKVersionが23(Android M)のため、Runtime Permission時の動作OSバージョンチェックは不要のため削除できます

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->