### PR TITLE
Fix #574 Deselect ListView item when back to  the help page

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -68,6 +68,7 @@
 - Elisa Sakamoto (Italian Translation)
 - Leo Ando (Client Android)
 - Prastyo ([Indonesian Translation](https://github.com/Covid-19Radar/Covid19Radar/commits?author=jiprastyo))
+- Kosuke Ogawa (Client iOS)
 
 # Beta Testers
 - Nagahata Kenji

--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpMenuPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpMenuPage.xaml
@@ -16,6 +16,7 @@
     <ScrollView>
         <StackLayout Style="{StaticResource DefaultStackLayout}">
             <ListView
+                x:Name="list_view"
                 ItemsSource="{Binding MenuItems}"
                 HasUnevenRows="True"
                 SelectedItem="{Binding SelectedMenuItem}"

--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpMenuPage.xaml.cs
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpMenuPage.xaml.cs
@@ -10,5 +10,10 @@ namespace Covid19Radar.Views
         {
             InitializeComponent();
         }
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            list_view.SelectedItem = null;
+        }
     }
 }


### PR DESCRIPTION


## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Deselect ListView item when back to  the help page #574 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/koogawa/Covid19Radar
cd Covid19Radar
git checkout fix/issue-574 
```

Build!

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
- the app deselect an item in the help listview when the app navigated back to the help page.
![xamarin](https://user-images.githubusercontent.com/893643/85253959-2c55b880-b49a-11ea-813b-5280eb0aa3c9.gif)


## Other Information
<!-- Add any other helpful information that may be needed here. -->