### PR TITLE
[iOS/Android] フォントサイズを大きくすると メニューの文字が見切れてしまう

### DIFF
--- a/Covid19Radar/Covid19Radar/Views/MenuPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/MenuPage.xaml
@@ -21,7 +21,7 @@
                 <ContentPage Title="{x:Static resources:AppResources.MenuPageTitle}" BackgroundColor="#FFFFFF">
                     <ListView
                         ItemsSource="{Binding MenuItems}"
-                        RowHeight="60"
+                        HasUnevenRows="True"
                         SelectedItem="{Binding SelectedMenuItem}"
                         SeparatorColor="#E0E0E0"
                         SeparatorVisibility="Default">


### PR DESCRIPTION
## Purpose

* #558 の修正

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

1. [設定] -> [アクセシビリティ] -> [画面表示とテキストサイズ] -> [さらに大きな文字]
2. フォントサイズを変更する

修正後、iOS では下図のように表示されます。

<img width="964" alt="スクリーンショット 2020-06-22 23 41 30" src="https://user-images.githubusercontent.com/137952/85301169-76628c80-b4e2-11ea-8d0f-d45a050076d6.png">

## What to Check

## Other Information

Xamarin.Formsのバージョンが 4.7.0.968 ですと、iOSシミュレータの場合ホーム画面に遷移するとクラッシュしてしまうため、一時的にXamarin.Formsのバージョンを  4.6.0.847 に下げて動作確認をおこないました。