### PR TITLE
接触の検出と通知を同時に変更すると後に変更した方が反映されない

### DIFF
--- a/Covid19Radar/Covid19Radar/Services/UserDataService.cs
+++ b/Covid19Radar/Covid19Radar/Services/UserDataService.cs
@@ -57,8 +57,8 @@ namespace Covid19Radar.Services
             {
                 return;
             }
-            current = userData;
-            Application.Current.Properties["UserData"] = Utils.SerializeToJson(current);
+            Application.Current.Properties["UserData"] = Utils.SerializeToJson(userData);
+            current = Get();
             await Application.Current.SavePropertiesAsync();
 
             UserDataChanged?.Invoke(this, current);


### PR DESCRIPTION
## Purpose
#602 の修正  
`current`に`userData`を代入しているだけなので、`userData`と`current`は同じ値になってしまい、更新処理が行われていなかった。  
`current `は、`Get()`で取得した新たなオブジェクトを代入するようにした

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
アプリの設定画面に遷移して、[接触の検出]と[通知]を両方ともOFFの状態からONに切り替えた後、他の画面に遷移して、再度、アプリの設定画面に遷移して、両方ともONであることを確認する

## What to Check
アプリの設定画面に再度遷移した時に、[接触の検出]と[通知]両方とも前に設定した状態が維持されていること