### PR TITLE
Fix #603 Empty cell appears on the menu screen

### DIFF
--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpMenuPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpMenuPage.xaml
@@ -21,7 +21,8 @@
                 HasUnevenRows="True"
                 SelectedItem="{Binding SelectedMenuItem}"
                 SeparatorColor="#E0E0E0"
-                SeparatorVisibility="Default">
+                SeparatorVisibility="Default"
+                Footer="">
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <ViewCell>

--- a/Covid19Radar/Covid19Radar/Views/MenuPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/MenuPage.xaml
@@ -24,7 +24,8 @@
                         RowHeight="60"
                         SelectedItem="{Binding SelectedMenuItem}"
                         SeparatorColor="#E0E0E0"
-                        SeparatorVisibility="Default">
+                        SeparatorVisibility="Default"
+                        Footer="">
 
                         <ListView.ItemTemplate>
                             <DataTemplate>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix https://github.com/Covid-19Radar/Covid19Radar/issues/603

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/akeome/Covid19Radar
cd Covid19Radar
git checkout bugfix/hide-empty-cells
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* Empty cells are not displayed on `MenuPage` and `HelpMenuPage` .

ScreenShots is here
* `MenuPage.xaml`

| Befor | After |
----|---- 
| <img src="https://user-images.githubusercontent.com/20479956/85330395-4c738f00-b50f-11ea-9878-1da21c481934.png"> | <img src="https://user-images.githubusercontent.com/20479956/85330438-5f865f00-b50f-11ea-8943-00e8c09b5488.png"> |

* `HelpMenuPage.xaml`

| Before | After |
----|---- 
| <img src="https://user-images.githubusercontent.com/20479956/85330958-37e3c680-b510-11ea-86e7-015357ccd691.png"> | <img src="https://user-images.githubusercontent.com/20479956/85331013-4f22b400-b510-11ea-8a4e-5466b97448e5.png"> |

## Other Information
<!-- Add any other helpful information that may be needed here. -->