### PR TITLE
Validating diagnosis uid in the NotifyOtherPage

### DIFF
--- a/Covid19Radar/Covid19Radar/Common/AppConstants.cs
+++ b/Covid19Radar/Covid19Radar/Common/AppConstants.cs
@@ -19,6 +19,10 @@
         /// Max Error Count
         /// </summary>
         public const int MaxErrorCount = 3;
+        /// <summary>
+        /// Max diagnosis UID Count
+        /// </summary>
+        public const int MaxDiagnosisUidCount = 8;
 
         public const string positiveRegex = @"\b[0-9]{8}\b";
 

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -15,8 +15,22 @@ namespace Covid19Radar.ViewModels
 {
     public class NotifyOtherPageViewModel : ViewModelBase
     {
-        public bool IsEnabled { get; set; }
-        public string DiagnosisUid { get; set; }
+        private string _diagnosisUid;
+        public string DiagnosisUid
+        {
+            get { return _diagnosisUid; }
+            set
+            {
+                SetProperty(ref _diagnosisUid, value);
+                IsEnabled = DiagnosisUid.Length == AppConstants.MaxDiagnosisUidCount;   // validate
+            }
+        }
+        private bool _isEnabled;
+        public bool IsEnabled
+        {
+            get { return _isEnabled; }
+            set { SetProperty(ref _isEnabled, value); }
+        }
         private int errorCount { get; set; }
 
         private readonly UserDataService userDataService;
@@ -28,7 +42,7 @@ namespace Covid19Radar.ViewModels
             this.userDataService = userDataService;
             userData = this.userDataService.Get();
             errorCount = 0;
-            IsEnabled = true;
+            DiagnosisUid = "";
         }
 
         public Command OnClickRegister => (new Command(async () =>
@@ -72,7 +86,7 @@ namespace Covid19Radar.ViewModels
 
 
             // Init Dialog
-            if (string.IsNullOrEmpty(DiagnosisUid))
+            if (string.IsNullOrEmpty(_diagnosisUid))
             {
                 await UserDialogs.Instance.AlertAsync(
                     AppResources.NotifyOtherPageDiag4Message,
@@ -86,7 +100,7 @@ namespace Covid19Radar.ViewModels
             }
 
             Regex regex = new Regex(AppConstants.positiveRegex);
-            if (!regex.IsMatch(DiagnosisUid))
+            if (!regex.IsMatch(_diagnosisUid))
             {
                 await UserDialogs.Instance.AlertAsync(
                     AppResources.NotifyOtherPageDiag5Message,
@@ -118,7 +132,7 @@ namespace Covid19Radar.ViewModels
                 }
 
                 // Set the submitted UID
-                userData.AddDiagnosis(DiagnosisUid, new DateTimeOffset(DateTime.Now));
+                userData.AddDiagnosis(_diagnosisUid, new DateTimeOffset(DateTime.Now));
                 await userDataService.SetAsync(userData);
 
                 // Submit our diagnosis
@@ -143,7 +157,6 @@ namespace Covid19Radar.ViewModels
             finally
             {
                 UserDialogs.Instance.HideLoading();
-                IsEnabled = true;
             }
         }));
     }

--- a/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml
@@ -7,6 +7,7 @@
     xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
     xmlns:prism="http://prismlibrary.com"
     xmlns:resources="clr-namespace:Covid19Radar.Resources"
+    xmlns:common="clr-namespace:Covid19Radar.Common"
     xmlns:system="clr-namespace:System;assembly=netstandard"
     Title="{x:Static resources:AppResources.NotifyOtherPageTitle}"
     ios:Page.UseSafeArea="true"
@@ -50,7 +51,7 @@
                             <Entry
                                 CharacterSpacing="5"
                                 Keyboard="Numeric"
-                                MaxLength="8"
+                                MaxLength="{x:Static common:AppConstants.MaxDiagnosisUidCount}"
                                 Placeholder="{x:Static resources:AppResources.NotifyOtherPageLabel2}"
                                 Style="{StaticResource DefaultEntry}"
                                 Text="{Binding DiagnosisUid}" />


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Change button state by a value of diagnosis uid. The user will be able to know what to do next depending on the input status of diagnosis UID.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: UI Improvement
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
1. Open "陽性情報の登録" > "同意して陽性登録する"
2. Confirm that "登録する" is disabled in first.
3. Input arbitrary 1~7 digit numbers.
4. Confirm that "登録する" remains disabled.
5. Input arbitrary 8 digit numbers.
6. Confirm that "登録する" becomes enabled.
```

## What to Check
Verify that the following are valid
* When a digit of diagnosis UID are 0~7, "登録する" has been disabled.
* When a digit of diagnosis UID is 8, "登録する" has been enabled.

## Other Information
This PR is rebase version of https://github.com/Covid-19Radar/Covid19Radar/pull/591.
