### PR TITLE
[Feature]Android App Bundle feature in release build

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Covid19Radar.Android.csproj
+++ b/Covid19Radar/Covid19Radar.Android/Covid19Radar.Android.csproj
@@ -69,7 +69,7 @@
     <EnableLLVM>false</EnableLLVM>
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <BundleAssemblies>true</BundleAssemblies>
-    <AndroidPackageFormat>apk</AndroidPackageFormat>
+    <AndroidPackageFormat>aab</AndroidPackageFormat>
     <AndroidDexTool>d8</AndroidDexTool>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidEnableMultiDex>true</AndroidEnableMultiDex>

--- a/Covid19Radar/Covid19Radar.Android/Properties/AndroidManifest.xml
+++ b/Covid19Radar/Covid19Radar.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="4" android:versionName="APP_VERSION" package="APP_PACKAGE_NAME" android:installLocation="internalOnly">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="4" android:versionName="APP_VERSION" package="APP_PACKAGE_NAME" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="29" />
 	<application android:debuggable="true" android:label="@string/app_name" android:icon="@mipmap/ic_launcher">
 		<receiver android:name=".nearby.ExposureNotificationBroadcastReceiver" android:permission="com.google.android.gms.nearby.exposurenotification.EXPOSURE_CALLBACK" android:exported="true">

--- a/Covid19Radar/Covid19Radar.Android/Properties/AndroidManifest.xml
+++ b/Covid19Radar/Covid19Radar.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="4" android:versionName="APP_VERSION" package="APP_PACKAGE_NAME" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="4" android:versionName="APP_VERSION" package="APP_PACKAGE_NAME" android:installLocation="internalOnly">
 	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="29" />
 	<application android:debuggable="true" android:label="@string/app_name" android:icon="@mipmap/ic_launcher">
 		<receiver android:name=".nearby.ExposureNotificationBroadcastReceiver" android:permission="com.google.android.gms.nearby.exposurenotification.EXPOSURE_CALLBACK" android:exported="true">


### PR DESCRIPTION
Android App Bundle feature in release build
Download size will probably be reduced to 50MB+.

[Limitation]
For apps deployed to devices running Android versions between 6.0 Marshmallow (API level 23) and 8.1 Oreo (API level 28), this feature currently only works if the app has the android:installLocation attribute set to "internalOnly" in the Android manifest.
https://docs.microsoft.com/en-us/xamarin/android/release-notes/9/9.4#initial-support-for-android-app-bundle-publishing-format