### PR TITLE
Fix #584

### DIFF
--- a/Covid19Radar/Covid19Radar/Services/UserDataService.cs
+++ b/Covid19Radar/Covid19Radar/Services/UserDataService.cs
@@ -63,6 +63,13 @@ namespace Covid19Radar.Services
 
             UserDataChanged?.Invoke(this, current);
         }
+
+        public async Task ClearAsync()
+        {
+            current = null;
+            Application.Current.Properties.Remove("UserData");
+            await Application.Current.SavePropertiesAsync();
+        }
     }
 
 }

--- a/Covid19Radar/Covid19Radar/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Settings/SettingsPageViewModel.cs
@@ -65,8 +65,7 @@ namespace Covid19Radar.ViewModels
                 }
 
                 // Reset All Data and Optout
-                UserDataModel userData = new UserDataModel();
-                await userDataService.SetAsync(userData);
+                await userDataService.ClearAsync();
 
                 UserDialogs.Instance.HideLoading();
                 await UserDialogs.Instance.AlertAsync(Resources.AppResources.SettingsPageDialogResetCompletedText);


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
#584 の修正になります。 使用停止の場合、ユーザー情報を初期状態(null)に戻し、ユーザーが再度登録処理を行ったあとアプリを使用できるようになります。

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
* アプリを初回起動し、チュートリアルを完了させる。
* 利用停止を行う
* アプリを再度起動し、チュートリアルを進める
```

## What to Check
Verify that the following are valid
* UserDataServiceについて、データ削除後に
     * currentがnullであること
     * Application.Current.PropertiesからUserDataが削除されていること
の2点を確認しました。

* ユーザ作成直後
<img width="861" alt="スクリーンショット 2020-06-23 13 22 35" src="https://user-images.githubusercontent.com/30116202/85360982-9d0ddb00-b555-11ea-8cd4-07f849a82c29.png">

* 利用停止後
<img width="892" alt="スクリーンショット 2020-06-23 13 20 14" src="https://user-images.githubusercontent.com/30116202/85360985-a008cb80-b555-11ea-9561-3e245becf815.png">


## Other Information
<!-- Add any other helpful information that may be needed here. -->