### PR TITLE
[Fix]Duplicate EN disable message.

### DIFF
--- a/Covid19Radar/Covid19Radar/Services/ExposureNotificationService.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureNotificationService.cs
@@ -43,7 +43,7 @@ namespace Covid19Radar.Services
             _downloadTimer.TimeOutEvent += OnTimerInvoked;
         }
 
-        private async void OnTimerInvoked(EventArgs e)
+        private void OnTimerInvoked(EventArgs e)
         {
             System.Diagnostics.Debug.WriteLine(DateTime.Now.ToString(new CultureInfo("en-US")));
             //await FetchExposureKeyAsync();
@@ -69,7 +69,7 @@ namespace Covid19Radar.Services
             Console.WriteLine("User Data has Changed!!!");
             this.userData = userDataService.Get();
             Console.WriteLine(Utils.SerializeToJson(userData));
-            await UpdateStatusMessage();
+            await UpdateStatusMessageAsync();
         }
 
         public async Task FetchExposureKeyAsync()
@@ -82,24 +82,22 @@ namespace Covid19Radar.Services
             return userData.ExposureInformation.Count();
         }
 
-        public async Task<string> UpdateStatusMessage()
+        public async Task<string> UpdateStatusMessageAsync()
         {
             this.ExposureNotificationStatus = await ExposureNotification.GetStatusAsync();
-            return GetStatusMessage();
+            return await GetStatusMessageAsync();
         }
 
         private async Task DisabledAsync()
         {
             userData.IsExposureNotificationEnabled = false;
             await userDataService.SetAsync(userData);
-            await UpdateStatusMessage();
         }
 
         private async Task EnabledAsync()
         {
             userData.IsExposureNotificationEnabled = true;
             await userDataService.SetAsync(userData);
-            await UpdateStatusMessage();
         }
 
 
@@ -147,18 +145,18 @@ namespace Covid19Radar.Services
             }
         }
 
-        public string GetStatusMessage()
+        private async Task<string> GetStatusMessageAsync()
         {
             var message = "";
 
             switch (ExposureNotificationStatus)
             {
                 case Status.Unknown:
-                    UserDialogs.Instance.AlertAsync(Resources.AppResources.ExposureNotificationStatusMessageUnknown, "", Resources.AppResources.ButtonOk);
+                    await UserDialogs.Instance.AlertAsync(Resources.AppResources.ExposureNotificationStatusMessageUnknown, "", Resources.AppResources.ButtonOk);
                     message = Resources.AppResources.ExposureNotificationStatusMessageUnknown;
                     break;
                 case Status.Disabled:
-                    UserDialogs.Instance.AlertAsync(Resources.AppResources.ExposureNotificationStatusMessageDisabled, "", Resources.AppResources.ButtonOk);
+                    await UserDialogs.Instance.AlertAsync(Resources.AppResources.ExposureNotificationStatusMessageDisabled, "", Resources.AppResources.ButtonOk);
                     message = Resources.AppResources.ExposureNotificationStatusMessageDisabled;
                     break;
                 case Status.Active:
@@ -166,12 +164,12 @@ namespace Covid19Radar.Services
                     break;
                 case Status.BluetoothOff:
                     // call out settings in each os
-                    UserDialogs.Instance.AlertAsync(Resources.AppResources.ExposureNotificationStatusMessageBluetoothOff, "", Resources.AppResources.ButtonOk);
+                    await UserDialogs.Instance.AlertAsync(Resources.AppResources.ExposureNotificationStatusMessageBluetoothOff, "", Resources.AppResources.ButtonOk);
                     message = Resources.AppResources.ExposureNotificationStatusMessageBluetoothOff;
                     break;
                 case Status.Restricted:
                     // call out settings in each os
-                    UserDialogs.Instance.AlertAsync(Resources.AppResources.ExposureNotificationStatusMessageRestricted, "", Resources.AppResources.ButtonOk);
+                    await UserDialogs.Instance.AlertAsync(Resources.AppResources.ExposureNotificationStatusMessageRestricted, "", Resources.AppResources.ButtonOk);
                     message = Resources.AppResources.ExposureNotificationStatusMessageRestricted;
                     break;
                 default:

--- a/Covid19Radar/Covid19Radar/ViewModels/Settings/DebugPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Settings/DebugPageViewModel.cs
@@ -26,7 +26,7 @@ namespace Covid19Radar.ViewModels
         private async void _userDataChanged(object sender, UserDataModel e)
         {
             _UserData = this.userDataService.Get();
-            _ = await exposureNotificationService.UpdateStatusMessage();
+            _ = await exposureNotificationService.UpdateStatusMessageAsync();
             _EnMessage = this.exposureNotificationService.CurrentStatusMessage;
         }
 
@@ -89,7 +89,7 @@ namespace Covid19Radar.ViewModels
         public Command UpdateStatus => new Command(async () =>
         {
             _UserData = this.userDataService.Get();
-            _ = await exposureNotificationService.UpdateStatusMessage();
+            _ = await exposureNotificationService.UpdateStatusMessageAsync();
             _EnMessage = this.exposureNotificationService.CurrentStatusMessage;
         });
 


### PR DESCRIPTION
[Fix]Duplicate EN disable message.

ExposureNotificationService.UpdateStatusMessageAsync() が、
OnUserDataChanged と EnabledAsync() or DisabledAsync() とで2回呼び出されているのが原因。
OnUserDataChanged() に集約で。