### PR TITLE
minSDKVersionが23のためLolipop(21)用のコードを削除

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/BackgroundService/BootReceiver.cs
+++ b/Covid19Radar/Covid19Radar.Android/BackgroundService/BootReceiver.cs
@@ -34,19 +34,7 @@ namespace Covid19Radar.Droid.BackgroundService
 
             //サービスを起動する
             Intent serviceIntent = new Intent(context, typeof(BackgroundService));
-
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop &&
-                Build.VERSION.SdkInt <= BuildVersionCodes.LollipopMr1)
-            {
-                // Android5 Lollipop
-                string packageName = context.PackageManager.GetPackageInfo(context.PackageName, 0).PackageName;
-                serviceIntent.SetPackage(packageName);
-                serviceIntent.SetClassName(context, packageName + ".BackgroundService");
-            }
-            else
-            {
-                serviceIntent.AddFlags(ActivityFlags.NewTask);
-            }
+            serviceIntent.AddFlags(ActivityFlags.NewTask);
 
             serviceIntent.SetPackage(context.PackageManager.GetPackageInfo(context.PackageName, 0).PackageName);
             // Android 8 Oreo


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
AndroidのminSDKVersionが23(Android M)のため、Lolipop(21)用の分岐は不要です。

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```
Sorry, development environment construction in now.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
rerate #580 