### PR TITLE
#629対応 EntryのStyleの文字サイズをDefault変更

### DIFF
--- a/Covid19Radar/Covid19Radar/App.xaml
+++ b/Covid19Radar/Covid19Radar/App.xaml
@@ -129,7 +129,7 @@
                 <Setter Property="TextColor" Value="{StaticResource PrimaryText}" />
                 <Setter Property="PlaceholderColor" Value="{StaticResource SecondaryText}" />
                 <Setter Property="HorizontalOptions" Value="FillAndExpand" />
-                <Setter Property="FontSize" Value="Small" />
+                <Setter Property="FontSize" Value="Default" />
                 <Setter Property="HeightRequest" Value="40" />
                 <Setter Property="Opacity" Value="0.6" />
                 <Style.Triggers>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* 陽性情報の登録ページにあるEntryの文字サイズが小さい。
利用者が番号を入力するので、もう少し文字サイズを大きくしてもよいのではと考えました。
Smallだった設定をDefaultに変更しました。
#629 対応
下記比較画像は、Issueに載せている画像と同じです。
![比較](https://user-images.githubusercontent.com/25080529/85649006-03713580-b6dd-11ea-8e8c-8ec731b75054.png)


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* 現時点でEntryの実装を行っているのは、陽性情報の登録ページのみ。
このページで文字を入力して確認する。

## Other Information
<!-- Add any other helpful information that may be needed here. -->