### PR TITLE
#660対応 メニュー画面の選択セルの色が戻らない不具合を修正

### DIFF
--- a/Covid19Radar/Covid19Radar/ViewModels/MenuPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/MenuPageViewModel.cs
@@ -196,6 +196,7 @@ namespace Covid19Radar.ViewModels
         async void Navigate()
         {
             await NavigationService.NavigateAsync(nameof(NavigationPage) + "/" + SelectedMenuItem.PageName);
+            SelectedMenuItem = null;
             return;
         }
 

--- a/Covid19Radar/Covid19Radar/Views/MenuPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/MenuPage.xaml
@@ -22,7 +22,7 @@
                     <ListView
                         ItemsSource="{Binding MenuItems}"
                         RowHeight="60"
-                        SelectedItem="{Binding SelectedMenuItem}"
+                        SelectedItem="{Binding SelectedMenuItem, Mode=TwoWay}"
                         SeparatorColor="#E0E0E0"
                         SeparatorVisibility="Default"
                         Footer="">


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* メニュー画面の選択セルの色が戻らない不具合を修正しました。
#660 対応

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* メニュー画面を表示して、任意のボタンをタップし、再度メニュー画面を表示しても、選択セルに色が付いていないこと。

## Other Information
<!-- Add any other helpful information that may be needed here. -->