### PR TITLE
[Fix] If UserData reset in Settings Page, StartDateTime is always displayed today.

### DIFF
--- a/Covid19Radar/Covid19Radar/Services/UserDataService.cs
+++ b/Covid19Radar/Covid19Radar/Services/UserDataService.cs
@@ -64,6 +64,13 @@ namespace Covid19Radar.Services
 
             UserDataChanged?.Invoke(this, current);
         }
+
+        public async Task ResetAllDataAsync()
+        {
+            Application.Current.Properties.Remove("UserData");
+            current = null;
+            await Application.Current.SavePropertiesAsync();
+        }
     }
 
 }

--- a/Covid19Radar/Covid19Radar/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Settings/SettingsPageViewModel.cs
@@ -72,8 +72,7 @@ namespace Covid19Radar.ViewModels
                 }
 
                 // Reset All Data and Optout
-                UserDataModel userData = new UserDataModel();
-                await userDataService.SetAsync(userData);
+                await userDataService.ResetAllDataAsync();
 
                 UserDialogs.Instance.HideLoading();
                 await UserDialogs.Instance.AlertAsync(Resources.AppResources.SettingsPageDialogResetCompletedText);


### PR DESCRIPTION
## Purpose
If UserData reset in Settings Page, StartDateTime is always displayed today.
