### PR TITLE
[iOS]ホーム画面で、InvalidCastExceptionが発生する

### DIFF
--- a/Covid19Radar/Covid19Radar/Views/MenuPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/MenuPage.xaml
@@ -49,7 +49,7 @@
                                                         <OnPlatform x:TypeArguments="BindingBase">
                                                             <OnPlatform.Platforms>
                                                                 <On Platform="Android" Value="{Binding IconColor}" />
-                                                                <On Platform="iOS" Value="#019AE8" />
+                                                                <On Platform="iOS" Value="{Binding Source=#019AE8}" />
                                                             </OnPlatform.Platforms>
                                                         </OnPlatform>
                                                     </FontImageSource.Color>
@@ -65,7 +65,7 @@
                                                 <OnPlatform x:TypeArguments="BindingBase">
                                                     <OnPlatform.Platforms>
                                                         <On Platform="Android" Value="{Binding TextColor}" />
-                                                        <On Platform="iOS" Value="{StaticResource NavBarText}" />
+                                                        <On Platform="iOS" Value="{Binding Source={StaticResource NavBarText}}" />
                                                     </OnPlatform.Platforms>
                                                 </OnPlatform>
                                             </Label.TextColor>                                                                                        


### PR DESCRIPTION
## Purpose
* #694 の修正
* #692 の修正の影響で、`OnPlatform`で、`BindingBase`を設定するようにしているのだが、iOSの場合は、`Color`を設定するようになっているので、`InvalidCastException`が発生していた
* iOSも`BindingBase`で設定するように修正した

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
iOSで起動して、ホーム画面から、サイドメニューを開く

## What to Check
* iOSでホーム画面を開いて、`InvalidCastException`が発生しないこと
* サイドメニュー画面のアイコンや、テキストの色が指定の色であること