### PR TITLE
(優先度：低)(Critical?：No)Fix #696 - Remove an unused image resource in the HelpPage3

### DIFF
--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage3.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage3.xaml
@@ -81,11 +81,6 @@
                         Style="{StaticResource DefaultLabel}"
                         Text="{x:Static resources:AppResources.HelpPage3Description3}"
                         VerticalTextAlignment="Center" />
-                    <ffimageloading:CachedImage
-                        Grid.Row="1"
-                        Grid.ColumnSpan="2"
-                        Aspect="AspectFit"
-                        Source="HelpPage43.png" />
                 </Grid>
                 <Grid ColumnSpacing="10" RowSpacing="0">
                     <Grid.ColumnDefinitions>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* #696 の修正になります。HelpPage3にて使用されない画像リソースHelpPage43.pngがあったため、例外でブレークする設定の場合にブレークしていました。

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
1. "メイン画面"を開く
1. "使い方"を開く
1. "新型コロナウイルスに感染していると判定されたら"を開く
```

## What to Check
Verify that the following are valid
* 例外でブレークする設定でデバッグ実行し、HelpPage3を開いても当該例外でブレークしないこと

## Other Information
<!-- Add any other helpful information that may be needed here. -->
なし