### PR TITLE
利用状況表示のUIが直感的でない #534 の実装

### DIFF
--- a/Covid19Radar/Covid19Radar/App.xaml
+++ b/Covid19Radar/Covid19Radar/App.xaml
@@ -26,6 +26,8 @@
             <Color x:Key="ButtonGrayedOut">#A4A4A4</Color>
             <Color x:Key="NavBarText">#000000</Color>
             <Color x:Key="NavBarBackground">#FFFFFF</Color>
+            <Color x:Key="AvailableColor">#31BA81</Color>
+            <Color x:Key="WarningColor">#E6D200</Color>
 
             <!--  Icons  -->
             <x:String x:Key="IconProfile">&#xf2bd;</x:String>
@@ -50,6 +52,8 @@
             <x:String x:Key="IconCancel">&#xf00d;</x:String>
             <x:String x:Key="IconRightArrow">&#xf35a;</x:String>
             <x:String x:Key="IconStar">&#xf005;</x:String>
+            <x:String x:Key="IconCheck">&#xf0e1e;</x:String>
+            <x:String x:Key="IconExclamation">&#xf1238;</x:String>
 
             <!--  FA-S  -->
             <x:String x:Key="IconHowToUse">&#xf51c;</x:String>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -361,6 +361,14 @@
     <value>アプリを周りの人に知らせる</value>
     <comment>アプリを周りの人に知らせる</comment>
   </data>
+  <data name="HomePageDescription6" xml:space="preserve">
+    <value>接触確認の設定はすべて有効です。</value>
+    <comment>接触確認の設定はすべて有効です。</comment>
+  </data>
+  <data name="HomePageDescription7" xml:space="preserve">
+    <value>機能が無効になっています。設定ページで接触の検出と通知をONにしてください。</value>
+    <comment>機能が無効になっています。設定ページで接触の検出と通知をONにしてください。</comment>
+  </data>
   <data name="HomePageTitle1" xml:space="preserve">
     <value>ホーム</value>
     <comment>ホーム</comment>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.resx
@@ -498,6 +498,14 @@
     <value>Share this app</value>
     <comment>アプリを周りの人に知らせる</comment>
   </data>
+  <data name="HomePageDescription6" xml:space="preserve">
+    <value>Contact confirmation settings are all enabled.</value>
+    <comment>接触確認の設定はすべて有効です。</comment>
+  </data>
+  <data name="HomePageDescription7" xml:space="preserve">
+    <value>Contact confirmation settings are disabled. Please turn on notifications and recording on the SettingsPage.</value>
+    <comment>機能が無効になっています。設定ページで接触の検出と通知をONにしてください。</comment>
+  </data>
   <data name="HomePageTitle1" xml:space="preserve">
     <value>Home</value>
     <comment>ホーム</comment>

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -28,6 +28,13 @@ namespace Covid19Radar.ViewModels
             set { SetProperty(ref _pastDate, value); }
         }
 
+        private bool _IsAvailable;
+        public bool IsAvailable
+        {
+            get => _IsAvailable;
+            set => SetProperty(ref _IsAvailable, value);
+        }
+
         public HomePageViewModel(INavigationService navigationService, UserDataService userDataService, ExposureNotificationService exposureNotificationService) : base(navigationService, userDataService, exposureNotificationService)
         {
             Title = AppResources.HomePageTitle;
@@ -39,6 +46,20 @@ namespace Covid19Radar.ViewModels
 
             TimeSpan timeSpan = DateTime.Now - userData.StartDateTime;
             PastDate = timeSpan.Days.ToString();
+
+            IsAvailable = userData.IsExposureNotificationEnabled && userData.IsNotificationEnabled;
+            this.userDataService.UserDataChanged += OnUserDataChanged;
+        }
+
+        public override void Destroy()
+        {
+            base.Destroy();
+            userDataService.UserDataChanged -= OnUserDataChanged;
+        }
+
+        private void OnUserDataChanged(object sender, UserDataModel e)
+        {            
+            IsAvailable = e.IsExposureNotificationEnabled && e.IsNotificationEnabled;
         }
 
         public override async void Initialize(INavigationParameters parameters)

--- a/Covid19Radar/Covid19Radar/Views/HomePage/HomePage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/HomePage.xaml
@@ -26,33 +26,98 @@
             Padding="15"
             BackgroundColor="#EEEEEE"
             Spacing="15">
-            <Frame
-                Padding="10"
-                CornerRadius="10"
-                HasShadow="False">
-                <StackLayout Spacing="0">
-                    <Label HorizontalTextAlignment="Center" Style="{StaticResource DefaultLabel}">
-                        <Label.FormattedText>
-                            <FormattedString>
-                                <Span Text="{Binding StartDate}" />
-                                <Span Text="{x:Static resources:AppResources.HomePageDescription0}" />
-                                <Span Text=" " />
-                                <Span Text="{Binding PastDate}" />
-                                <Span Text=" " />
-                                <Span Text="{x:Static resources:AppResources.HomePagePastDays}" />
-                                <Span Text=" " />
-                                <Span Text="{x:Static resources:AppResources.HomePageDescription1}" />
-                            </FormattedString>
-                        </Label.FormattedText>
-                    </Label>
-                    <Button
-                        AutomationId="ButtonExposures"
-                        Command="{Binding Path=OnClickExposures}"
-                        Style="{StaticResource DefaultButton}"
-                        Text="{x:Static resources:AppResources.HomePageDescription2}" />
 
-                </StackLayout>
-            </Frame>
+            <Grid ColumnSpacing="16" RowSpacing="0" HorizontalOptions="FillAndExpand" Margin="10,15,10,0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <BoxView Grid.Row="0" Grid.RowSpan="2" Grid.Column="0" CornerRadius="21" Color="{StaticResource AvailableColor}"
+                         WidthRequest="42" HeightRequest="42" VerticalOptions="Center" HorizontalOptions="Center">
+                    <BoxView.Triggers>
+                        <DataTrigger TargetType="BoxView" Binding="{Binding IsAvailable}" Value="False">
+                            <Setter Property="Color" Value="{StaticResource WarningColor}" />
+                        </DataTrigger>
+                    </BoxView.Triggers>
+                </BoxView>
+                <BoxView Grid.Row="0" Grid.RowSpan="2" Grid.Column="0" CornerRadius="18" Color="{StaticResource Background}"
+                         WidthRequest="36" HeightRequest="36" VerticalOptions="Center" HorizontalOptions="Center" />
+                <Label Grid.Row="0" Grid.RowSpan="2" Grid.Column="0" FontFamily="MaterialFontFamily" Text="{StaticResource IconCheck}"
+                       TextColor="{StaticResource AvailableColor}" FontSize="24" VerticalOptions="Center" HorizontalOptions="Center">
+                    <Label.Triggers>
+                        <DataTrigger TargetType="Label" Binding="{Binding IsAvailable}" Value="False">
+                            <Setter Property="TextColor" Value="{StaticResource WarningColor}" />
+                            <Setter Property="Text" Value="{StaticResource IconExclamation}" />
+                        </DataTrigger>
+                    </Label.Triggers>
+                </Label>
+
+                <Label Grid.Row="0" Grid.Column="1" TextColor="{StaticResource PrimaryText}" FontSize="Body" Padding="0">
+                    <Label.Margin>
+                        <OnPlatform x:TypeArguments="Thickness">
+                            <On Platform="Android" Value="0,0,0,-10" />
+                        </OnPlatform>
+                    </Label.Margin>
+                    <Label.FormattedText>
+                        <FormattedString>
+                            <Span Text="{Binding StartDate}" FontFamily="NotoSansMediumFontFamily" FontSize="Body"/>
+                            <Span Text="{x:Static resources:AppResources.HomePageDescription0}" FontFamily="NotoSansRegularFontFamily" FontSize="Body" />
+                            <Span Text=" " />
+                            <Span Text="{Binding PastDate}" FontFamily="NotoSansMediumFontFamily" FontSize="Body"/>
+                            <Span Text=" " />
+                            <Span Text="{x:Static resources:AppResources.HomePagePastDays}" FontFamily="NotoSansMediumFontFamily" FontSize="Body"/>
+                            <Span Text=" " />
+                            <Span Text="{x:Static resources:AppResources.HomePageDescription1}" FontFamily="NotoSansRegularFontFamily" FontSize="Body"/>
+                        </FormattedString>
+                    </Label.FormattedText>
+                </Label>                
+
+                <Label Grid.Row="1" Grid.Column="1" TextColor="{StaticResource AvailableColor}" Style="{StaticResource DefaultLabel}" IsVisible="{Binding IsAvailable}"
+                       Text="{x:Static resources:AppResources.HomePageDescription6}" FontSize="Body">                    
+                    <Label.Margin>
+                        <OnPlatform x:TypeArguments="Thickness">
+                            <On Platform="Android" Value="0,-10,0,0" />
+                        </OnPlatform>
+                    </Label.Margin>
+                </Label>
+
+                <Label Grid.Row="1" Grid.Column="1" Style="{StaticResource DefaultLabel}" FontSize="Body" Text="{x:Static resources:AppResources.HomePageDescription7}">
+                    <Label.Triggers>
+                        <DataTrigger TargetType="Label" Binding="{Binding IsAvailable}" Value="True">
+                            <Setter Property="IsVisible" Value="False" />
+                        </DataTrigger>
+                    </Label.Triggers>
+                    <Label.Margin>
+                        <OnPlatform x:TypeArguments="Thickness">
+                            <On Platform="Android" Value="0,-10,0,0" />
+                        </OnPlatform>
+                    </Label.Margin>
+                </Label>
+            </Grid>
+
+            <Button
+                AutomationId="ButtonSetting"
+                Command="{prism:NavigateTo 'SettingsPage'}"
+                Style="{StaticResource DefaultButton}"
+                Text="{x:Static resources:AppResources.HelpPage4ButtonText}">
+                <Button.Triggers>
+                    <DataTrigger TargetType="Button" Binding="{Binding IsAvailable}" Value="True">
+                        <Setter Property="IsVisible" Value="False" />
+                    </DataTrigger>
+                </Button.Triggers>
+            </Button>
+                
+            <Button
+                    AutomationId="ButtonExposures"
+                    Command="{Binding Path=OnClickExposures}"
+                    Style="{StaticResource DefaultButton}"
+                    Text="{x:Static resources:AppResources.HomePageDescription2}" />
+
             <Frame
                 Padding="10"
                 CornerRadius="10"


### PR DESCRIPTION
## Purpose

#534 利用状況表示のUIが直感的でない
の実装です。


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check

設定ページで「接触の検出」または「通知」をOFFにしたときにホームページで設定を促す表示に変わり
両方の設定をONにしたときに設定が有効であることを知らせる表示に動的に変化することを確認しました。

## Other Information

この表現方法に関してはまだ議論が必要かも知れませんが、実装例としてPRしました。
また言語は、日本語と英語を設定していますが、英語は仮なので、ちゃんとした翻訳が必要かと思います。