### PR TITLE
(優先度：中)(Critical?：Middle)処理番号の入力欄について、数字以外の入力を無効にする

### DIFF
--- a/Covid19Radar/Covid19Radar/Behaviors/NumberOnlyBehavior.cs
+++ b/Covid19Radar/Covid19Radar/Behaviors/NumberOnlyBehavior.cs
@@ -1,0 +1,36 @@
+﻿using System.Linq;
+using Xamarin.Forms;
+
+namespace Covid19Radar.Behaviors
+{
+    public class NumberOnlyBehavior : Behavior<Entry>
+    {
+        protected override void OnAttachedTo(Entry entry)
+        {
+            entry.TextChanged += OnEntryTextChanged;
+            base.OnAttachedTo(entry);
+        }
+
+        protected override void OnDetachingFrom(Entry entry)
+        {
+            entry.TextChanged -= OnEntryTextChanged;
+            base.OnDetachingFrom(entry);
+        }
+
+        private static void OnEntryTextChanged(object sender, TextChangedEventArgs args)
+        {
+            if (!string.IsNullOrWhiteSpace(args.NewTextValue))
+            {
+                char[] newTextArray = args.NewTextValue.ToCharArray();
+                bool isNumberOnly = newTextArray.All(x => char.IsDigit(x));
+                if (isNumberOnly)
+                {
+                    ((Entry)sender).Text = args.NewTextValue;
+                } else
+                {
+                    ((Entry)sender).Text = args.OldTextValue;
+                }
+            }
+        }
+    }
+}

--- a/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml
@@ -9,6 +9,7 @@
     xmlns:resources="clr-namespace:Covid19Radar.Resources"
     xmlns:common="clr-namespace:Covid19Radar.Common"
     xmlns:system="clr-namespace:System;assembly=netstandard"
+    xmlns:Behavior="clr-namespace:Covid19Radar.Behaviors"
     Title="{x:Static resources:AppResources.NotifyOtherPageTitle}"
     ios:Page.UseSafeArea="true"
     prism:ViewModelLocator.AutowireViewModel="True"
@@ -54,7 +55,11 @@
                                 MaxLength="{x:Static common:AppConstants.MaxDiagnosisUidCount}"
                                 Placeholder="{x:Static resources:AppResources.NotifyOtherPageLabel2}"
                                 Style="{StaticResource DefaultEntry}"
-                                Text="{Binding DiagnosisUid}" />
+                                Text="{Binding DiagnosisUid}">
+                                <Entry.Behaviors>
+                                  <Behavior:NumberOnlyBehavior />
+                                </Entry.Behaviors>
+                            </Entry>
                         </Frame>
                     </Frame>
                     <Frame


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
"陽性情報の登録"について、処理番号の入力欄に数字以外も入力できるようになっていました※
"登録する"ボタンをタップしたときに数字のみかどうかバリデーションされますが、番号入力時に制限しておくことで番号のみ入力できることを直感的にわかるようにしています。

※ 数字キーボードで入力する設定はされていましたが、入力直後の制限はありませんでした。また、"."が入力可能になっていました。

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
* 数字1桁を入力すると、そのまま入力欄に反映される
* 数字以外を入力しても、入力欄は更新されずそのままになる
```

## What to Check
Verify that the following are valid
* 入力欄には数字のみ入力できること
* 入力欄に数字以外を入力したとき、入力欄が更新されないこと
* "登録する"をタップし入力内容をバリデーションするときに、入力欄の入力内容と_diagnosisUidの値が一致していること

## Other Information
<!-- Add any other helpful information that may be needed here. -->