### PR TITLE
Fix #725: 陽性情報の入力(NotifyOtherPage)画面 登録ダイアログでキャンセルしたときのダイアログは不要

### DIFF
--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -50,11 +50,6 @@ namespace Covid19Radar.ViewModels
             var result = await UserDialogs.Instance.ConfirmAsync(AppResources.NotifyOtherPageDiag1Message, AppResources.NotifyOtherPageDiag1Title, AppResources.ButtonAgree, AppResources.ButtonCancel);
             if (!result)
             {
-                await UserDialogs.Instance.AlertAsync(
-                    AppResources.NotifyOtherPageDiag2Message,
-                    "",
-                    Resources.AppResources.ButtonOk
-                    );
                 return;
             }
 


### PR DESCRIPTION
## Purpose
陽性情報の入力(NotifyOtherPage)画面で登録ダイアログでキャンセルしたときのダイアログを削除し、ユーザーの操作の手間を1ステップ減らしました。

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* 登録ダイアログがdismissした後、キャンセルダイアログが表示されないこと

## Other Information
メッセージで'キャンセルしました'を表す言語リソースNotifyOtherPageDiag2Message については残しています。今後メッセージを他の場所で流用される可能性があるためです。