### PR TITLE
Fix #724, 登録待ちをLoading表示に変更＋ダイアログ表示のタイミングで5秒カウント開始

### DIFF
--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -81,7 +81,8 @@ namespace Covid19Radar.ViewModels
                     + AppResources.NotifyOtherPageDiag3Message;
                 UserDialogs.Instance.ShowLoading(message);
                 await Task.Delay(errorCount * 5000);
-            } else
+            }
+            else
             {
                 UserDialogs.Instance.ShowLoading(AppResources.LoadingTextRegistering);
             }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -58,8 +58,6 @@ namespace Covid19Radar.ViewModels
                 return;
             }
 
-            UserDialogs.Instance.ShowLoading(Resources.AppResources.LoadingTextRegistering);
-
             // Check helthcare authority positive api check here!!
             if (errorCount >= AppConstants.MaxErrorCount)
             {
@@ -77,13 +75,16 @@ namespace Covid19Radar.ViewModels
             {
                 var current = errorCount + 1;
                 var max = AppConstants.MaxErrorCount;
-                await UserDialogs.Instance.AlertAsync(AppResources.NotifyOtherPageDiag3Message,
-                    AppResources.NotifyOtherPageDiag3Title + $"{current}/{max}",
-                    Resources.AppResources.ButtonOk
-                    );
+                
+                string message = AppResources.NotifyOtherPageDiag3Title
+                    + $"({current}/{max})\n\n"
+                    + AppResources.NotifyOtherPageDiag3Message;
+                UserDialogs.Instance.ShowLoading(message);
                 await Task.Delay(errorCount * 5000);
+            } else
+            {
+                UserDialogs.Instance.ShowLoading(AppResources.LoadingTextRegistering);
             }
-
 
             // Init Dialog
             if (string.IsNullOrEmpty(_diagnosisUid))


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
#724 について、登録待ちの表示をローディング表示に変更し、なおかつローディング表示開始から5秒後に以降の処理を進めるように変更しました。

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
#724 参照

## What to Check
Verify that the following are valid
* 登録待ちの表示のとき、ダイアログではなくLoading表示されること

## Other Information
* iOS 登録待ち表示(日本語)
![await_registration_ja](https://user-images.githubusercontent.com/30116202/86506313-5350aa80-be09-11ea-86d7-d5b91d74f37e.jpeg)

* iOS 登録待ち表示(英語)
![await_registration_en](https://user-images.githubusercontent.com/30116202/86506343-8abf5700-be09-11ea-9ca6-99914f9b325e.jpeg)

* Android 登録待ち表示(日本語) ※ タブレットサイズ
![Screenshot_1593843102](https://user-images.githubusercontent.com/30116202/86506319-5e0b3f80-be09-11ea-88e7-01f6c8aeca47.jpeg)

* Android 登録待ち表示(英語) ※ タブレットサイズ
![Screenshot_1593843003](https://user-images.githubusercontent.com/30116202/86506320-61063000-be09-11ea-978d-4e617afe5b58.jpeg)

