### PR TITLE
Revert "Fix #724, 登録待ちをLoading表示に変更＋ダイアログ表示のタイミングで5秒カウント開始"

### DIFF
--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -58,6 +58,8 @@ namespace Covid19Radar.ViewModels
                 return;
             }
 
+            UserDialogs.Instance.ShowLoading(Resources.AppResources.LoadingTextRegistering);
+
             // Check helthcare authority positive api check here!!
             if (errorCount >= AppConstants.MaxErrorCount)
             {
@@ -75,17 +77,13 @@ namespace Covid19Radar.ViewModels
             {
                 var current = errorCount + 1;
                 var max = AppConstants.MaxErrorCount;
-                
-                string message = AppResources.NotifyOtherPageDiag3Title
-                    + $"({current}/{max})\n\n"
-                    + AppResources.NotifyOtherPageDiag3Message;
-                UserDialogs.Instance.ShowLoading(message);
+                await UserDialogs.Instance.AlertAsync(AppResources.NotifyOtherPageDiag3Message,
+                    AppResources.NotifyOtherPageDiag3Title + $"{current}/{max}",
+                    Resources.AppResources.ButtonOk
+                    );
                 await Task.Delay(errorCount * 5000);
             }
-            else
-            {
-                UserDialogs.Instance.ShowLoading(AppResources.LoadingTextRegistering);
-            }
+
 
             // Init Dialog
             if (string.IsNullOrEmpty(_diagnosisUid))


### PR DESCRIPTION
Reverts Covid-19Radar/Covid19Radar#727