### PR TITLE
【Android/iOS】読み上げテキストの設定修正

### DIFF
--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage3.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage3.xaml
@@ -130,7 +130,9 @@
             </StackLayout>
             <Grid Grid.Row="1">
                 <Button
-                    AutomationId="{x:Static resources:AppResources.HelpPage3Description6}"
+                    AutomationId="NextButton"
+                    AutomationProperties.IsInAccessibleTree="true"
+                    AutomationProperties.Name="{x:Static resources:AppResources.HelpPage3Description6}"
                     Command="{Binding Path=OnClickNotifyOtherPage}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.HelpPage3Description6}" />

--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage3.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage3.xaml
@@ -130,7 +130,7 @@
             </StackLayout>
             <Grid Grid.Row="1">
                 <Button
-                    AutomationId="NextButton"
+                    AutomationId="{x:Static resources:AppResources.HelpPage3Description6}"
                     Command="{Binding Path=OnClickNotifyOtherPage}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.HelpPage3Description6}" />

--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage4.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage4.xaml
@@ -27,7 +27,7 @@
             </StackLayout>
             <Grid Grid.Row="1">
                 <Button
-                    AutomationId="OnClickSetting"
+                    AutomationId="{x:Static resources:AppResources.HelpPage4ButtonText}"
                     Command="{Binding Path=OnClickSetting}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.HelpPage4ButtonText}" />

--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage4.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage4.xaml
@@ -27,7 +27,9 @@
             </StackLayout>
             <Grid Grid.Row="1">
                 <Button
-                    AutomationId="{x:Static resources:AppResources.HelpPage4ButtonText}"
+                    AutomationId="OnClickSetting"
+                    AutomationProperties.IsInAccessibleTree="true"
+                    AutomationProperties.Name="{x:Static resources:AppResources.HelpPage4ButtonText}"
                     Command="{Binding Path=OnClickSetting}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.HelpPage4ButtonText}" />

--- a/Covid19Radar/Covid19Radar/Views/HomePage/ContactedNotifyPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/ContactedNotifyPage.xaml
@@ -47,6 +47,8 @@
                     <Button
                         Margin="0,0,0,20"
                         AutomationId="ButtonShareApp"
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="{x:Static resources:AppResources.ContactedNotifyPageButton2}"
                         Command="{Binding Path=OnClickByForm}"
                         Style="{StaticResource DefaultButton}"
                         Text="{x:Static resources:AppResources.ContactedNotifyPageButton2}" />
@@ -54,6 +56,8 @@
                     <Button
                         Margin="0,0,0,20"
                         AutomationId="ButtonShareApp"
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="{x:Static resources:AppResources.ContactedNotifyPageButton3}"
                         Command="{Binding Path=OnClickByPhone}"
                         Style="{StaticResource DefaultButton}"
                         Text="{x:Static resources:AppResources.ContactedNotifyPageButton3}" />
@@ -72,6 +76,8 @@
             </Frame>
             <Button
                 AutomationId="OnClickExposures"
+                AutomationProperties.IsInAccessibleTree="true"
+                AutomationProperties.Name="{x:Static resources:AppResources.ContactedNotifyPageButton1}"
                 Command="{prism:NavigateTo 'ExposuresPage'}"
                 Style="{StaticResource DefaultButton}"
                 Text="{x:Static resources:AppResources.ContactedNotifyPageButton1}" />

--- a/Covid19Radar/Covid19Radar/Views/HomePage/HomePage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/HomePage.xaml
@@ -15,6 +15,8 @@
     <ContentPage.ToolbarItems>
         <ToolbarItem
             AutomationId="LabelMainTutorial"
+            AutomationProperties.IsInAccessibleTree="true"
+            AutomationProperties.Name="{x:Static resources:AppResources.MainTutorial}"
             Command="{prism:NavigateTo 'HelpMenuPage'}"
             Order="Primary"
             Priority="1"

--- a/Covid19Radar/Covid19Radar/Views/HomePage/HomePage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/HomePage.xaml
@@ -47,6 +47,8 @@
                     </Label>
                     <Button
                         AutomationId="ButtonExposures"
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="{x:Static resources:AppResources.HomePageDescription2}"
                         Command="{Binding Path=OnClickExposures}"
                         Style="{StaticResource DefaultButton}"
                         Text="{x:Static resources:AppResources.HomePageDescription2}" />
@@ -81,6 +83,8 @@
                     </Grid>
 
                     <Button
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="{x:Static resources:AppResources.HomePageDescription4}"
                         Command="{prism:NavigateTo 'SubmitConsentPage'}"
                         Style="{StaticResource DefaultButton}"
                         Text="{x:Static resources:AppResources.HomePageDescription4}" />
@@ -113,6 +117,8 @@
                             VerticalTextAlignment="Center" />
                     </Grid>
                     <Button
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="{x:Static resources:AppResources.HomePageDescription5}"
                         Command="{Binding Path=OnClickShareApp}"
                         Style="{StaticResource DefaultButton}"
                         Text="{x:Static resources:AppResources.HomePageDescription5}" />

--- a/Covid19Radar/Covid19Radar/Views/HomePage/NotContactPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/NotContactPage.xaml
@@ -47,6 +47,8 @@
             <Grid Grid.Row="1">
                 <Button
                     AutomationId="OnClickShareApp"
+                    AutomationProperties.IsInAccessibleTree="true"
+                    AutomationProperties.Name="{x:Static resources:AppResources.NotContactPageButtonText}"
                     Command="{Binding Path=OnClickShareApp}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.NotContactPageButtonText}" />

--- a/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml
@@ -71,6 +71,8 @@
             <Grid Grid.Row="1">
                 <Button
                     AutomationId="NextButton"
+                    AutomationProperties.IsInAccessibleTree="true"
+                    AutomationProperties.Name="{x:Static resources:AppResources.NotifyOtherPageButton}"
                     Command="{Binding Path=OnClickRegister}"
                     IsEnabled="{Binding IsEnabled}"
                     Style="{StaticResource DefaultButton}"

--- a/Covid19Radar/Covid19Radar/Views/HomePage/SubmitConsentPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/SubmitConsentPage.xaml
@@ -33,6 +33,8 @@
             <Grid Grid.Row="1">
                 <Button
                     AutomationId="NextButton"
+                    AutomationProperties.IsInAccessibleTree="true"
+                    AutomationProperties.Name="{x:Static resources:AppResources.SubmitConsentPageDescription6}"
                     Command="{prism:NavigateTo 'NotifyOtherPage'}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.SubmitConsentPageDescription6}" />

--- a/Covid19Radar/Covid19Radar/Views/HomePage/ThankYouNotifyOtherPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/ThankYouNotifyOtherPage.xaml
@@ -41,6 +41,8 @@
             <Grid Grid.Row="1">
                 <Button
                     AutomationId="OnClickShareApp"
+                    AutomationProperties.IsInAccessibleTree="true"
+                    AutomationProperties.Name="{x:Static resources:AppResources.NotContactPageButtonText}"
                     Command="{Binding Path=OnClickShareApp}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.NotContactPageButtonText}" />

--- a/Covid19Radar/Covid19Radar/Views/Settings/DebugPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Settings/DebugPage.xaml
@@ -76,24 +76,32 @@
                     </StackLayout>
 
                     <Button
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="利用規約リセット"
                         Command="{Binding ToggleWelcome}"
                         HorizontalOptions="CenterAndExpand"
                         Style="{StaticResource DefaultButton}"
                         Text="利用規約リセット" />
 
                     <Button
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="Reset Last Enabled State"
                         Command="{Binding ResetEnabled}"
                         HorizontalOptions="CenterAndExpand"
                         Style="{StaticResource DefaultButton}"
                         Text="Reset Last Enabled State" />
 
                     <Button
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="Update Status"
                         Command="{Binding UpdateStatus}"
                         HorizontalOptions="CenterAndExpand"
                         Style="{StaticResource DefaultButton}"
                         Text="Update Status" />
 
                     <Button
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="EN状態トグル"
                         Command="{Binding ToggleEn}"
                         HorizontalOptions="CenterAndExpand"
                         Style="{StaticResource DefaultButton}"
@@ -108,6 +116,8 @@
                         Text="通知トグル" />
 
                     <Button
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="Reset Self Diagnosis"
                         Command="{Binding ResetSelfDiagnosis}"
                         HorizontalOptions="CenterAndExpand"
                         Style="{StaticResource DefaultButton}"
@@ -120,11 +130,15 @@
                         Style="{StaticResource DefaultLabelSmallColor}"
                         Text="Exposures" />
                     <Button
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="Reset Exposures"
                         Command="{Binding ResetExposures}"
                         HorizontalOptions="CenterAndExpand"
                         Style="{StaticResource DefaultButton}"
                         Text="Reset Exposures" />
                     <Button
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="Add Exposures"
                         Command="{Binding AddExposures}"
                         HorizontalOptions="CenterAndExpand"
                         Style="{StaticResource DefaultButton}"
@@ -146,12 +160,16 @@
                     </StackLayout>
 
                     <Button
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="Reset Batch File Index"
                         Command="{Binding ResetBatchFileIndex}"
                         HorizontalOptions="CenterAndExpand"
                         Style="{StaticResource DefaultButton}"
                         Text="Reset Batch File Index" />
 
                     <Button
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="Trigger Key Fetch"
                         Command="{Binding ManualTriggerKeyFetch}"
                         HorizontalOptions="CenterAndExpand"
                         Style="{StaticResource DefaultButton}"

--- a/Covid19Radar/Covid19Radar/Views/Settings/SettingsPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Settings/SettingsPage.xaml
@@ -179,6 +179,8 @@
                     <Button
                         Grid.Row="0"
                         Grid.Column="1"
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="{x:Static resources:AppResources.ButtonReset}"
                         Command="{Binding OnChangeResetData}"
                         HorizontalOptions="End"
                         Scale="0.8"

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/PrivacyPolicyPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/PrivacyPolicyPage.xaml
@@ -29,7 +29,7 @@
             Style="{StaticResource DefaultWebView}" />
         <Button
             Grid.Row="2"
-            AutomationId="ButtonAgree"
+            AutomationId="{x:Static resources:AppResources.ButtonAgree}"
             Command="{Binding Path=OnClickAgree}"
             Style="{StaticResource DefaultButton}"
             Text="{x:Static resources:AppResources.ButtonAgree}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/PrivacyPolicyPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/PrivacyPolicyPage.xaml
@@ -29,7 +29,9 @@
             Style="{StaticResource DefaultWebView}" />
         <Button
             Grid.Row="2"
-            AutomationId="{x:Static resources:AppResources.ButtonAgree}"
+            AutomationId="ButtonAgree"
+            AutomationProperties.IsInAccessibleTree="true"
+            AutomationProperties.Name="{x:Static resources:AppResources.ButtonAgree}"
             Command="{Binding Path=OnClickAgree}"
             Style="{StaticResource DefaultButton}"
             Text="{x:Static resources:AppResources.ButtonAgree}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage1.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage1.xaml
@@ -92,7 +92,7 @@
                 </StackLayout>
                 <Button
                     Grid.Row="1"
-                    AutomationId="NextButton"
+                    AutomationId="{x:Static resources:AppResources.TutorialPage1Button}"
                     Command="{prism:NavigateTo 'TutorialPage2'}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.TutorialPage1Button}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage1.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage1.xaml
@@ -92,7 +92,9 @@
                 </StackLayout>
                 <Button
                     Grid.Row="1"
-                    AutomationId="{x:Static resources:AppResources.TutorialPage1Button}"
+                    AutomationId="NextButton"
+                    AutomationProperties.IsInAccessibleTree="true"
+                    AutomationProperties.Name="{x:Static resources:AppResources.TutorialPage1Button}"
                     Command="{prism:NavigateTo 'TutorialPage2'}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.TutorialPage1Button}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage2.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage2.xaml
@@ -34,7 +34,7 @@
                 <Label Style="{StaticResource DefaultLabel}" Text="{x:Static resources:AppResources.TutorialPage2Description4}" />
                 <Button
                     Grid.Row="1"
-                    AutomationId="NextButton"
+                    AutomationId="{x:Static resources:AppResources.TutorialPage2Description5}"
                     Command="{prism:NavigateTo 'TutorialPage3'}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.TutorialPage2Description5}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage2.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage2.xaml
@@ -34,7 +34,9 @@
                 <Label Style="{StaticResource DefaultLabel}" Text="{x:Static resources:AppResources.TutorialPage2Description4}" />
                 <Button
                     Grid.Row="1"
-                    AutomationId="{x:Static resources:AppResources.TutorialPage2Description5}"
+                    AutomationId="NextButton"
+                    AutomationProperties.IsInAccessibleTree="true"
+                    AutomationProperties.Name="{x:Static resources:AppResources.TutorialPage2Description5}"
                     Command="{prism:NavigateTo 'TutorialPage3'}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.TutorialPage2Description5}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage3.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage3.xaml
@@ -40,7 +40,7 @@
         </StackLayout>
         <Button
             Grid.Row="2"
-            AutomationId="NextButton"
+            AutomationId="{x:Static resources:AppResources.TutorialPage3ButtonText}"
             Command="{Binding Path=OnClickAgree}"
             Style="{StaticResource DefaultButton}"
             Text="{x:Static resources:AppResources.TutorialPage3ButtonText}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage3.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage3.xaml
@@ -40,7 +40,9 @@
         </StackLayout>
         <Button
             Grid.Row="2"
-            AutomationId="{x:Static resources:AppResources.TutorialPage3ButtonText}"
+            AutomationId="NextButton"
+            AutomationProperties.IsInAccessibleTree="true"
+            AutomationProperties.Name="{x:Static resources:AppResources.TutorialPage3ButtonText}"
             Command="{Binding Path=OnClickAgree}"
             Style="{StaticResource DefaultButton}"
             Text="{x:Static resources:AppResources.TutorialPage3ButtonText}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage4.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage4.xaml
@@ -41,14 +41,14 @@
                 <Grid Grid.Row="1">
                     <StackLayout>
                         <Button
-                        AutomationId="EnableButton"
+                        AutomationId="{x:Static resources:AppResources.TutorialPage4Button1}"
                         Command="{Binding Path=OnClickEnable}"
                         Style="{StaticResource DefaultButton}"
                         Text="{x:Static resources:AppResources.TutorialPage4Button1}" />
 
                         <Button
                         Margin="0,10,0,0"
-                        AutomationId="DisableButton"
+                        AutomationId="{x:Static resources:AppResources.TutorialPage4Button2}"
                         Command="{Binding Path=OnClickDisable}"
                         Style="{StaticResource DefaultButtonGrayedOut}"
                         Text="{x:Static resources:AppResources.TutorialPage4Button2}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage4.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage4.xaml
@@ -41,14 +41,18 @@
                 <Grid Grid.Row="1">
                     <StackLayout>
                         <Button
-                        AutomationId="{x:Static resources:AppResources.TutorialPage4Button1}"
+                        AutomationId="EnableButton"
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="{x:Static resources:AppResources.TutorialPage4Button1}"
                         Command="{Binding Path=OnClickEnable}"
                         Style="{StaticResource DefaultButton}"
                         Text="{x:Static resources:AppResources.TutorialPage4Button1}" />
 
                         <Button
                         Margin="0,10,0,0"
-                        AutomationId="{x:Static resources:AppResources.TutorialPage4Button2}"
+                        AutomationId="DisableButton"
+                        AutomationProperties.IsInAccessibleTree="true"
+                        AutomationProperties.Name="{x:Static resources:AppResources.TutorialPage4Button2}"
                         Command="{Binding Path=OnClickDisable}"
                         Style="{StaticResource DefaultButtonGrayedOut}"
                         Text="{x:Static resources:AppResources.TutorialPage4Button2}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage5.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage5.xaml
@@ -34,14 +34,14 @@
                 </StackLayout>
                 <StackLayout Grid.Row="1">
                     <Button
-                    AutomationId="EnableButton"
+                    AutomationId="{x:Static resources:AppResources.TutorialPage5Description3}"
                     Command="{Binding Path=OnClickEnable}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.TutorialPage5Description3}" />
 
                     <Button
                     Margin="0,10,0,0"
-                    AutomationId="DisableButton"
+                    AutomationId="{x:Static resources:AppResources.TutorialPage5Description4}"
                     Command="{Binding Path=OnClickDisable}"
                     Style="{StaticResource DefaultButtonGrayedOut}"
                     Text="{x:Static resources:AppResources.TutorialPage5Description4}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage5.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage5.xaml
@@ -34,14 +34,18 @@
                 </StackLayout>
                 <StackLayout Grid.Row="1">
                     <Button
-                    AutomationId="{x:Static resources:AppResources.TutorialPage5Description3}"
+                    AutomationId="EnableButton"
+                    AutomationProperties.IsInAccessibleTree="true"
+                    AutomationProperties.Name="{x:Static resources:AppResources.TutorialPage5Description3}"
                     Command="{Binding Path=OnClickEnable}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.TutorialPage5Description3}" />
 
                     <Button
                     Margin="0,10,0,0"
-                    AutomationId="{x:Static resources:AppResources.TutorialPage5Description4}"
+                    AutomationId="DisableButton"
+                    AutomationProperties.IsInAccessibleTree="true"
+                    AutomationProperties.Name="{x:Static resources:AppResources.TutorialPage5Description4}"
                     Command="{Binding Path=OnClickDisable}"
                     Style="{StaticResource DefaultButtonGrayedOut}"
                     Text="{x:Static resources:AppResources.TutorialPage5Description4}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage6.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage6.xaml
@@ -38,13 +38,13 @@
             </StackLayout>
             <StackLayout Grid.Row="1" Margin="0,0,0,20">
                 <Button
-                    AutomationId="NextButton"
+                    AutomationId="{x:Static resources:AppResources.TutorialPage6ButtonText1}"
                     Command="{prism:NavigateTo '/MenuPage/NavigationPage/HomePage'}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.TutorialPage6ButtonText1}" />
                 <Button
                     Margin="0,10,0,0"
-                    AutomationId="NextButton"
+                    AutomationId="{x:Static resources:AppResources.TutorialPage6ButtonText2}"
                     Command="{prism:NavigateTo '/MenuPage/NavigationPage/HelpMenuPage'}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.TutorialPage6ButtonText2}" />

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage6.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage6.xaml
@@ -38,13 +38,17 @@
             </StackLayout>
             <StackLayout Grid.Row="1" Margin="0,0,0,20">
                 <Button
-                    AutomationId="{x:Static resources:AppResources.TutorialPage6ButtonText1}"
+                    AutomationId="NextButton"
+                    AutomationProperties.IsInAccessibleTree="true"
+                    AutomationProperties.Name="{x:Static resources:AppResources.TutorialPage6ButtonText1}"
                     Command="{prism:NavigateTo '/MenuPage/NavigationPage/HomePage'}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.TutorialPage6ButtonText1}" />
                 <Button
                     Margin="0,10,0,0"
-                    AutomationId="{x:Static resources:AppResources.TutorialPage6ButtonText2}"
+                    AutomationId="NextButton"
+                    AutomationProperties.IsInAccessibleTree="true"
+                    AutomationProperties.Name="{x:Static resources:AppResources.TutorialPage6ButtonText2}"
                     Command="{prism:NavigateTo '/MenuPage/NavigationPage/HelpMenuPage'}"
                     Style="{StaticResource DefaultButton}"
                     Text="{x:Static resources:AppResources.TutorialPage6ButtonText2}" />


### PR DESCRIPTION
## Purpose
UI 表示されているテキストと読み上げ音声が一致しない箇所があるので、その修正をしました。
関連Issue は#596 で、このプルリクエストではAndroid の一部を修正しました。
対応しきれなかったことは"Other Information" に記載しましたので、お手数ですがこちらもご確認のほどよろしくお願いします。


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```


## How to Test
なし


## What to Check
Android 端末で下記の読み上げを試してみてください。

ファイル名 | UI 上の表示
--- | ---
HelpPage/HelpPage3.xaml | 「陽性情報の登録と他者への匿名通知へ」
HelpPage/HelpPage4.xaml | 「アプリの設定へ」
HomePage/HomePage.xaml | 「陽性者との接触を確認する」
HomePage/NotContactPage.xaml | 「アプリを周りの人に知らせる」
HomePage/NotifyOtherPage.xaml | 「登録する」
HomePage/SubmitConsentPage.xaml | 「同意して陽性登録する」
Settings/SettingsPage.xaml | 「使用中止」
Tutorial/PrivacyPolicyPage.xaml | 「同意する」
Tutorial/TutorialPage1.xaml | 「次へ」
Tutorial/TutorialPage2.xaml | 「利用規約へ」
Tutorial/TutorialPage3.xaml | 「規約に同意して次へ」
Tutorial/TutorialPage4.xaml | 「あとで設定する」<br />「有効にする」
Tutorial/TutorialPage6.xaml | 「使い方を学ぶ」<br />「ホーム画面へ」

下記も同様の修正をしましたが、検証しきれませんでした。

ファイル名 | UI 上の表示
--- | ---
HomePage/ContactedNotifyPage.xaml | 「症状を入力して相談」<br />「電話で症状を伝えて相談」<br />「陽性者との接触一覧」
HomePage/NotifyOtherPage.xaml | 「登録する」
HomePage/ThankYouNotifyOtherPage.xaml | 「アプリを周りの人に知らせる」
Settings/DebugPage.xaml | 各メニュー
Tutorial/TutorialPage5.xaml | 「あとで設定する」<br />「有効にする」


## Other Information
<!-- Add any other helpful information that may be needed here. -->
### 読み上げ方法
Android では「すべて読み上げ」時は問題なかったですが、「選択読み上げ」すると表示テキストと音声が一致しませんでした。

OS | すべて読み上げ | 選択読み上げ
--- | :---: | :---:
Android | ![Android すべて読み上げ][droid-all] | ![Android 選択して読み上げ][droid-part]
iOS | (未確認) | (未確認)

### 対応出来なかったこと
* InqueryPageDescription1 に適切な音声を当てる
→ "9:00～17:30" の"～" が特に悩ましく、「から」などと当てるのが良いかもです。
→ 別Issue を立ててそちらで考えたいと思います。
* iOS 読み上げの検証
→ 実機デバッグをうまくできなかったので、その方法をまとめるIssue を立てて対応したいと思います。
* 画面上部ツールバー(ヘッダー) の戻るボタンの読み上げテキスト設定
→ 「戻る」に相当する文字列リソースがないため、各言語に追加する形になりそうなので断念しました。
→ 別Issue を立ててそちらで対応したいと思います。


[droid-all]: https://user-images.githubusercontent.com/29895868/87437776-b1f7fe80-c629-11ea-9fdb-a7b81c6834a7.gif
[droid-part]: https://user-images.githubusercontent.com/29895868/87437902-d653db00-c629-11ea-83a6-bd1685ee51d8.gif
