### PR TITLE
Fix #755 : ReadMe内のリンク切れの修正

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -75,6 +75,7 @@
 - Tassana Thaveeteeratham (Thai Translation)
 - Kotaro Sakamoto
 - Koichi Yokota (Documentation)
+- Takashi Kishida (Documentation)
 
 # Original Covid19Radar Beta Testers
 - Nagahata Kenji

--- a/README.ja.md
+++ b/README.ja.md
@@ -55,7 +55,7 @@ https://visualstudio.microsoft.com/ja/xamarin/
 
 設定完了後、本アプリをインストールしている人同士の接触ログを自動で記録します。
 
-開発環境の構築については、[こちらのドキュメント](doc/Developer.md)を参照してください。
+開発環境の構築については、[こちらのドキュメント](doc/Developer-Note.md)を参照してください。
 
 # デザインについて
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Permission to use the following functions of the device is required.
 
 After the setup is complete, the contact log between the people who have installed this app is automatically recorded.
 
-For more information on setting up a development environment, please refer to [this document](doc/Developer.md).
+For more information on setting up a development environment, please refer to [this document](doc/Developer-Note.md).
 
 # About the design
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* #755 README内の「開発環境の構築については、"こちらのドキュメント"を参照してください。」の部分でリンク切れが起きていたので修正しました。
 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* README内の該当箇所のリンクをクリックして doc/Developer-Note.md に飛べること。

## Other Information
<!-- Add any other helpful information that may be needed here. -->