### PR TITLE
Fix #760 : お問い合わせメールにAPPデバイス情報とアプリバージョンを記載

### DIFF
--- a/Covid19Radar/Covid19Radar/ViewModels/HelpPage/InqueryPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HelpPage/InqueryPageViewModel.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Covid19Radar.Resources;
 using Xamarin.Essentials;
 using Xamarin.Forms;
+using Xamarin.Essentials;
 
 namespace Covid19Radar.ViewModels
 {
@@ -33,6 +35,20 @@ namespace Covid19Radar.ViewModels
 
         public Command OnClickEmail => new Command(async () =>
         {
+            // Device Model (SMG-950U, iPhone10,6)
+            var device = DeviceInfo.Model;
+
+            // Manufacturer (Samsung)
+            var manufacturer = DeviceInfo.Manufacturer;
+
+            // Operating System Version Number (7.0)
+            var version = DeviceInfo.VersionString;
+
+            // Platform (Android)
+            var platform = DeviceInfo.Platform;
+
+            var device_info = "DEVICE_INFO : " + AppSettings.Instance.AppVersion + "," + device + "("+ manufacturer + ")," + platform + "," + version;
+            Debug.WriteLine("DEVICE_INFO : " + device_info);
 
             try
             {
@@ -41,7 +57,7 @@ namespace Covid19Radar.ViewModels
                 var message = new EmailMessage
                 {
                     Subject = AppResources.InqueryMailSubject,
-                    Body = AppResources.InqueryMailBody.Replace("\\r\\n", "\r\n"),
+                    Body = device_info + "\r\n" + AppResources.InqueryMailBody.Replace("\\r\\n", "\r\n"),
                     To = recipients
                 };
                 await Email.ComposeAsync(message);


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* #760 に対応。不具合対応を行う際に、どの機種でどのOSでどのバージョンで不具合が発生しているかを切り分けるためにiOSかAndroidかなどOSの情報とアプリのバージョンを表記する。GMS非対応の端末などは対応していないため切り分けのために必要。

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* アプリに関するお問い合わせを選択
* appsupport@cov19.mhlw.go.jpをタップ
* メールフォームを確認し、DEVICE_INFOが追記されていることを確認
```
DEVICE_INFO : APP_VERSION,Pixel 2 XL,(Google),Android,10
お名前：
ご連絡先：
お問い合わせ内容(カテゴリを次の中からお選びください)：1.アプリの仕組み、2.アプリの設定、 3.アプリの利用(通知など)、 4.その他
お問い合わせ本文：
```

## Other Information
<!-- Add any other helpful information that may be needed here. -->