### PR TITLE
Solve Issue #770: Added News Page

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -77,6 +77,7 @@
 - Koichi Yokota (Documentation)
 - Takashi Kishida (Documentation)
 - Yusuke Yamada (Xamarin)
+- Takym (News Page)
 
 # Original Covid19Radar Beta Testers
 - Nagahata Kenji

--- a/Covid19Radar/Covid19Radar/App.xaml.cs
+++ b/Covid19Radar/Covid19Radar/App.xaml.cs
@@ -146,6 +146,10 @@ namespace Covid19Radar
             containerRegistry.RegisterForNavigation<SubmitConsentPage>();
             containerRegistry.RegisterForNavigation<ExposuresPage>();
 
+            // News
+            containerRegistry.RegisterForNavigation<NewsPage>();
+            containerRegistry.RegisterForNavigation<WebViewerPage>();
+
             // Services
             containerRegistry.RegisterSingleton<UserDataService>();
             containerRegistry.RegisterSingleton<ExposureNotificationService>();

--- a/Covid19Radar/Covid19Radar/Common/AppUtils.cs
+++ b/Covid19Radar/Covid19Radar/Common/AppUtils.cs
@@ -1,4 +1,8 @@
-﻿using Acr.UserDialogs;
+﻿#if !DEBUG
+#define NDEBUG
+#endif
+
+using Acr.UserDialogs;
 using Covid19Radar.Resources;
 using Newtonsoft.Json.Linq;
 using System;
@@ -40,6 +44,7 @@ namespace Covid19Radar.Common
 
         }
 
+        [Conditional("NDEBUG")] // デバッグ時は呼び出さない
         public static async void CheckVersion()
         {
             var uri = AppResources.UrlVersion;

--- a/Covid19Radar/Covid19Radar/Covid19Radar.csproj
+++ b/Covid19Radar/Covid19Radar/Covid19Radar.csproj
@@ -187,6 +187,12 @@
     <EmbeddedResource Update="Views\HomePage\ExposuresPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="Views\NewsPage\NewsPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Views\NewsPage\WebViewerPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MultilingualResources\" />

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.en.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.en.xlf
@@ -907,12 +907,12 @@
           <target state="translated">News</target>
           <note from="MultilingualBuild" annotates="source" priority="2">最新情報ページ</note>
         </trans-unit>
-        <trans-unit id="NewsPageUrl" translate="yes" xml:space="preserve">
+        <trans-unit id="GoogleSearchUrl" translate="yes" xml:space="preserve">
           <source>https://www.google.us/search?hl=en&amp;q=Coronavirus+disease+2019</source>
           <target state="translated">https://www.google.us/search?hl=en&amp;q=Coronavirus+disease+2019</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">最新情報ページで表示するWebページ (暫定的にGoogle)</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">最新情報ページで表示するGoogle検索</note>
         </trans-unit>
-        <trans-unit id="NewsPageButton_ShowPage" translate="yes" xml:space="preserve">
+        <trans-unit id="NewsPageButton_ShowGoogle" translate="yes" xml:space="preserve">
           <source>Search News on Google</source>
           <target state="translated">Search News on Google</target>
           <note from="MultilingualBuild" annotates="source" priority="2"></note>
@@ -926,6 +926,26 @@
           <source>Anti-Coronavirus Dashboard</source>
           <target state="translated">Anti-Coronavirus Dashboard</target>
           <note from="MultilingualBuild" annotates="source" priority="2"></note>
+        </trans-unit>
+        <trans-unit id="CoronaGoJPUrl" translate="yes" xml:space="preserve">
+          <source>https://corona.go.jp/en/</source>
+          <target state="translated">https://corona.go.jp/en/</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">内閣官房のデータ</note>
+        </trans-unit>
+        <trans-unit id="NewsPageButton_ShowCoronaGoJP" translate="yes" xml:space="preserve">
+          <source>Data by Cabinet Secretariat</source>
+          <target state="translated">Data by Cabinet Secretariat</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">内閣官房のデータ</note>
+        </trans-unit>
+        <trans-unit id="NewsPageLabel_Links" translate="yes" xml:space="preserve">
+          <source>Links</source>
+          <target state="translated">Links</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">リンク集</note>
+        </trans-unit>
+        <trans-unit id="NewsPageLabel_LinksDescription" translate="yes" xml:space="preserve">
+          <source>You can search information about new corona.</source>
+          <target state="translated">You can search information about new corona.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">新型コロナに関する情報を調べる事ができます。</note>
         </trans-unit>
       </group>
     </body>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.en.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.en.xlf
@@ -902,6 +902,31 @@
           <target state="needs-review-translation" state-qualifier="mt-suggestion">There is a problem with the contact record data</target>
           <note from="MultilingualBuild" annotates="source" priority="2">接触記録データに問題があります</note>
         </trans-unit>
+        <trans-unit id="NewsPageTitle" translate="yes" xml:space="preserve">
+          <source>News</source>
+          <target state="translated">News</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">最新情報ページ</note>
+        </trans-unit>
+        <trans-unit id="NewsPageUrl" translate="yes" xml:space="preserve">
+          <source>https://www.google.us/search?hl=en&amp;q=Coronavirus+disease+2019</source>
+          <target state="translated">https://www.google.us/search?hl=en&amp;q=Coronavirus+disease+2019</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">最新情報ページで表示するWebページ (暫定的にGoogle)</note>
+        </trans-unit>
+        <trans-unit id="NewsPageButton_ShowPage" translate="yes" xml:space="preserve">
+          <source>Search News on Google</source>
+          <target state="translated">Search News on Google</target>
+          <note from="MultilingualBuild" annotates="source" priority="2"></note>
+        </trans-unit>
+        <trans-unit id="StopCOVID19JPUrl" translate="yes" xml:space="preserve">
+          <source>https://www.stopcovid19.jp/#en</source>
+          <target state="translated">https://www.stopcovid19.jp/#en</target>
+          <note from="MultilingualBuild" annotates="source" priority="2"></note>
+        </trans-unit>
+        <trans-unit id="NewsPageButton_ShowStopCOVID19JP" translate="yes" xml:space="preserve">
+          <source>Anti-Coronavirus Dashboard</source>
+          <target state="translated">Anti-Coronavirus Dashboard</target>
+          <note from="MultilingualBuild" annotates="source" priority="2"></note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ja.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ja.xlf
@@ -901,6 +901,31 @@
           <target state="translated">接触記録データに問題があります</target>
           <note from="MultilingualBuild" annotates="source" priority="2">接触記録データに問題があります</note>
         </trans-unit>
+        <trans-unit id="NewsPageTitle" translate="yes" xml:space="preserve">
+          <source>News</source>
+          <target state="translated">最新情報</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">最新情報ページ</note>
+        </trans-unit>
+        <trans-unit id="NewsPageUrl" translate="yes" xml:space="preserve">
+          <source>https://www.google.us/search?hl=en&amp;q=Coronavirus+disease+2019</source>
+          <target state="translated">https://www.google.co.jp/search?hl=ja&amp;q=2019年新型コロナウイルス感染症</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">最新情報ページで表示するWebページ (暫定的にGoogle)</note>
+        </trans-unit>
+        <trans-unit id="NewsPageButton_ShowPage" translate="yes" xml:space="preserve">
+          <source>Search News on Google</source>
+          <target state="translated">最新情報をGoogleで検索</target>
+          <note from="MultilingualBuild" annotates="source" priority="2"></note>
+        </trans-unit>
+        <trans-unit id="StopCOVID19JPUrl" translate="yes" xml:space="preserve">
+          <source>https://www.stopcovid19.jp/#en</source>
+          <target state="translated">https://www.stopcovid19.jp/#ja</target>
+          <note from="MultilingualBuild" annotates="source" priority="2"></note>
+        </trans-unit>
+        <trans-unit id="NewsPageButton_ShowStopCOVID19JP" translate="yes" xml:space="preserve">
+          <source>Anti-Coronavirus Dashboard</source>
+          <target state="translated">対策ダッシュボード</target>
+          <note from="MultilingualBuild" annotates="source" priority="2"></note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ja.xlf
+++ b/Covid19Radar/Covid19Radar/MultilingualResources/Covid19Radar.ja.xlf
@@ -906,12 +906,12 @@
           <target state="translated">最新情報</target>
           <note from="MultilingualBuild" annotates="source" priority="2">最新情報ページ</note>
         </trans-unit>
-        <trans-unit id="NewsPageUrl" translate="yes" xml:space="preserve">
+        <trans-unit id="GoogleSearchUrl" translate="yes" xml:space="preserve">
           <source>https://www.google.us/search?hl=en&amp;q=Coronavirus+disease+2019</source>
           <target state="translated">https://www.google.co.jp/search?hl=ja&amp;q=2019年新型コロナウイルス感染症</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">最新情報ページで表示するWebページ (暫定的にGoogle)</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">最新情報ページで表示するGoogle検索</note>
         </trans-unit>
-        <trans-unit id="NewsPageButton_ShowPage" translate="yes" xml:space="preserve">
+        <trans-unit id="NewsPageButton_ShowGoogle" translate="yes" xml:space="preserve">
           <source>Search News on Google</source>
           <target state="translated">最新情報をGoogleで検索</target>
           <note from="MultilingualBuild" annotates="source" priority="2"></note>
@@ -925,6 +925,26 @@
           <source>Anti-Coronavirus Dashboard</source>
           <target state="translated">対策ダッシュボード</target>
           <note from="MultilingualBuild" annotates="source" priority="2"></note>
+        </trans-unit>
+        <trans-unit id="CoronaGoJPUrl" translate="yes" xml:space="preserve">
+          <source>https://corona.go.jp/en/</source>
+          <target state="translated">https://corona.go.jp/dashboard/</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">内閣官房のデータ</note>
+        </trans-unit>
+        <trans-unit id="NewsPageButton_ShowCoronaGoJP" translate="yes" xml:space="preserve">
+          <source>Data by Cabinet Secretariat</source>
+          <target state="translated">内閣官房のデータ</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">内閣官房のデータ</note>
+        </trans-unit>
+        <trans-unit id="NewsPageLabel_Links" translate="yes" xml:space="preserve">
+          <source>Links</source>
+          <target state="translated">リンク集</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">リンク集</note>
+        </trans-unit>
+        <trans-unit id="NewsPageLabel_LinksDescription" translate="yes" xml:space="preserve">
+          <source>You can search information about new corona.</source>
+          <target state="translated">新型コロナに関する情報を調べる事ができます。</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">新型コロナに関する情報を調べる事ができます。</note>
         </trans-unit>
       </group>
     </body>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
@@ -934,6 +934,42 @@ namespace Covid19Radar.Resources {
         }
         
         /// <summary>
+        ///   Search News on Google に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string NewsPageButton_ShowPage {
+            get {
+                return ResourceManager.GetString("NewsPageButton_ShowPage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Anti-Coronavirus Dashboard に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string NewsPageButton_ShowStopCOVID19JP {
+            get {
+                return ResourceManager.GetString("NewsPageButton_ShowStopCOVID19JP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   News に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string NewsPageTitle {
+            get {
+                return ResourceManager.GetString("NewsPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   https://www.google.us/search?hl=en&amp;q=Coronavirus+disease+2019 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string NewsPageUrl {
+            get {
+                return ResourceManager.GetString("NewsPageUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Share this app に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string NotContactPageButtonText {
@@ -1290,6 +1326,15 @@ namespace Covid19Radar.Resources {
         internal static string SettingsPageTitle {
             get {
                 return ResourceManager.GetString("SettingsPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   https://www.stopcovid19.jp/#en に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string StopCOVID19JPUrl {
+            get {
+                return ResourceManager.GetString("StopCOVID19JPUrl", resourceCulture);
             }
         }
         

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
@@ -250,6 +250,15 @@ namespace Covid19Radar.Resources {
         }
         
         /// <summary>
+        ///   https://corona.go.jp/en/ に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string CoronaGoJPUrl {
+            get {
+                return ResourceManager.GetString("CoronaGoJPUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Exposure Notification could not startup. Open the terminal settings, turn in Exposure Notification, and turn in Bluetooth. に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string DialogExposureNotificationStartupError {
@@ -408,6 +417,15 @@ namespace Covid19Radar.Resources {
         internal static string ExposuresPageTitle {
             get {
                 return ResourceManager.GetString("ExposuresPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   https://www.google.us/search?hl=en&amp;q=Coronavirus+disease+2019 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string GoogleSearchUrl {
+            get {
+                return ResourceManager.GetString("GoogleSearchUrl", resourceCulture);
             }
         }
         
@@ -934,11 +952,20 @@ namespace Covid19Radar.Resources {
         }
         
         /// <summary>
+        ///   Data by Cabinet Secretariat に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string NewsPageButton_ShowCoronaGoJP {
+            get {
+                return ResourceManager.GetString("NewsPageButton_ShowCoronaGoJP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Search News on Google に類似しているローカライズされた文字列を検索します。
         /// </summary>
-        internal static string NewsPageButton_ShowPage {
+        internal static string NewsPageButton_ShowGoogle {
             get {
-                return ResourceManager.GetString("NewsPageButton_ShowPage", resourceCulture);
+                return ResourceManager.GetString("NewsPageButton_ShowGoogle", resourceCulture);
             }
         }
         
@@ -952,20 +979,29 @@ namespace Covid19Radar.Resources {
         }
         
         /// <summary>
+        ///   Links に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string NewsPageLabel_Links {
+            get {
+                return ResourceManager.GetString("NewsPageLabel_Links", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   You can search information about new corona. に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string NewsPageLabel_LinksDescription {
+            get {
+                return ResourceManager.GetString("NewsPageLabel_LinksDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   News に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string NewsPageTitle {
             get {
                 return ResourceManager.GetString("NewsPageTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   https://www.google.us/search?hl=en&amp;q=Coronavirus+disease+2019 に類似しているローカライズされた文字列を検索します。
-        /// </summary>
-        internal static string NewsPageUrl {
-            get {
-                return ResourceManager.GetString("NewsPageUrl", resourceCulture);
             }
         }
         

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -722,4 +722,24 @@
     <value>連絡先レコードデータに問題があります</value>
     <comment>接触記録データに問題があります</comment>
   </data>
+  <data name="NewsPageTitle" xml:space="preserve">
+    <value>最新情報</value>
+    <comment>最新情報ページ</comment>
+  </data>
+  <data name="NewsPageUrl" xml:space="preserve">
+    <value>https://www.google.co.jp/search?hl=ja&amp;q=2019年新型コロナウイルス感染症</value>
+    <comment>最新情報ページで表示するWebページ (暫定的にGoogle)</comment>
+  </data>
+  <data name="NewsPageButton_ShowPage" xml:space="preserve">
+    <value>最新情報をGoogleで検索</value>
+    <comment></comment>
+  </data>
+	<data name="StopCOVID19JPUrl" xml:space="preserve">
+    <value>https://www.stopcovid19.jp/#ja</value>
+    <comment></comment>
+  </data>
+	<data name="NewsPageButton_ShowStopCOVID19JP" xml:space="preserve">
+    <value>対策ダッシュボード</value>
+    <comment></comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -726,11 +726,11 @@
     <value>最新情報</value>
     <comment>最新情報ページ</comment>
   </data>
-  <data name="NewsPageUrl" xml:space="preserve">
+  <data name="GoogleSearchUrl" xml:space="preserve">
     <value>https://www.google.co.jp/search?hl=ja&amp;q=2019年新型コロナウイルス感染症</value>
-    <comment>最新情報ページで表示するWebページ (暫定的にGoogle)</comment>
+    <comment>最新情報ページで表示するGoogle検索</comment>
   </data>
-  <data name="NewsPageButton_ShowPage" xml:space="preserve">
+  <data name="NewsPageButton_ShowGoogle" xml:space="preserve">
     <value>最新情報をGoogleで検索</value>
     <comment></comment>
   </data>
@@ -741,5 +741,21 @@
 	<data name="NewsPageButton_ShowStopCOVID19JP" xml:space="preserve">
     <value>対策ダッシュボード</value>
     <comment></comment>
+  </data>
+  <data name="CoronaGoJPUrl" xml:space="preserve">
+    <value>https://corona.go.jp/dashboard/</value>
+    <comment>内閣官房のデータ</comment>
+  </data>
+  <data name="NewsPageButton_ShowCoronaGoJP" xml:space="preserve">
+    <value>内閣官房のデータ</value>
+    <comment>内閣官房のデータ</comment>
+  </data>
+  <data name="NewsPageLabel_Links" xml:space="preserve">
+    <value>リンク集</value>
+    <comment>リンク集</comment>
+  </data>
+  <data name="NewsPageLabel_LinksDescription" xml:space="preserve">
+    <value>新型コロナに関する情報を調べる事ができます。</value>
+    <comment>新型コロナに関する情報を調べる事ができます。</comment>
   </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.resx
@@ -827,4 +827,24 @@
     <value>There is a problem with the contact record data</value>
     <comment>接触記録データに問題があります</comment>
   </data>
+  <data name="NewsPageTitle" xml:space="preserve">
+    <value>News</value>
+    <comment>最新情報ページ</comment>
+  </data>
+  <data name="NewsPageUrl" xml:space="preserve">
+    <value>https://www.google.us/search?hl=en&amp;q=Coronavirus+disease+2019</value>
+    <comment>最新情報ページで表示するWebページ (暫定的にGoogle)</comment>
+  </data>
+  <data name="NewsPageButton_ShowPage" xml:space="preserve">
+    <value>Search News on Google</value>
+    <comment></comment>
+  </data>
+  <data name="StopCOVID19JPUrl" xml:space="preserve">
+    <value>https://www.stopcovid19.jp/#en</value>
+    <comment></comment>
+  </data>
+  <data name="NewsPageButton_ShowStopCOVID19JP" xml:space="preserve">
+    <value>Anti-Coronavirus Dashboard</value>
+    <comment></comment>
+  </data>
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.resx
@@ -831,11 +831,11 @@
     <value>News</value>
     <comment>最新情報ページ</comment>
   </data>
-  <data name="NewsPageUrl" xml:space="preserve">
+  <data name="GoogleSearchUrl" xml:space="preserve">
     <value>https://www.google.us/search?hl=en&amp;q=Coronavirus+disease+2019</value>
-    <comment>最新情報ページで表示するWebページ (暫定的にGoogle)</comment>
+    <comment>最新情報ページで表示するGoogle検索</comment>
   </data>
-  <data name="NewsPageButton_ShowPage" xml:space="preserve">
+  <data name="NewsPageButton_ShowGoogle" xml:space="preserve">
     <value>Search News on Google</value>
     <comment></comment>
   </data>
@@ -846,5 +846,21 @@
   <data name="NewsPageButton_ShowStopCOVID19JP" xml:space="preserve">
     <value>Anti-Coronavirus Dashboard</value>
     <comment></comment>
+  </data>
+  <data name="CoronaGoJPUrl" xml:space="preserve">
+    <value>https://corona.go.jp/en/</value>
+    <comment>内閣官房のデータ</comment>
+  </data>
+  <data name="NewsPageButton_ShowCoronaGoJP" xml:space="preserve">
+    <value>Data by Cabinet Secretariat</value>
+    <comment>内閣官房のデータ</comment>
+  </data>
+  <data name="NewsPageLabel_Links" xml:space="preserve">
+    <value>Links</value>
+    <comment>リンク集</comment>
+  </data>
+  <data name="NewsPageLabel_LinksDescription" xml:space="preserve">
+    <value>You can search information about new corona.</value>
+    <comment>新型コロナに関する情報を調べる事ができます。</comment>
   </data>
 </root>

--- a/Covid19Radar/Covid19Radar/ViewModels/MenuPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/MenuPageViewModel.cs
@@ -34,7 +34,7 @@ namespace Covid19Radar.ViewModels
                 TextColor = "#000"
             });
             MenuItems.Add(new MainMenuModel() {
-                Icon = "\ud83d\udcf0", //"\uf0c0",
+                Icon = "\uf0c0", //"\ue85c", //"\ud83d\udcf0",
                 PageName = nameof(NewsPage),
                 Title = Resources.AppResources.NewsPageTitle,
                 IconColor = "#019AE8",

--- a/Covid19Radar/Covid19Radar/ViewModels/MenuPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/MenuPageViewModel.cs
@@ -33,7 +33,13 @@ namespace Covid19Radar.ViewModels
                 IconColor = "#019AE8",
                 TextColor = "#000"
             });
-
+            MenuItems.Add(new MainMenuModel() {
+                Icon = "\ud83d\udcf0", //"\uf0c0",
+                PageName = nameof(NewsPage),
+                Title = Resources.AppResources.NewsPageTitle,
+                IconColor = "#019AE8",
+                TextColor = "#000"
+            });
             MenuItems.Add(new MainMenuModel()
             {
                 Icon = "\uf013",
@@ -42,7 +48,6 @@ namespace Covid19Radar.ViewModels
                 IconColor = "#019AE8",
                 TextColor = "#000"
             });
-
             MenuItems.Add(new MainMenuModel()
             {
                 Icon = "\uf0e0",
@@ -201,7 +206,7 @@ namespace Covid19Radar.ViewModels
                 Title = nameof(SubmitConsentPage)
             });
 #endif
-            */
+            //*/
             NavigateCommand = new DelegateCommand(Navigate);
         }
 

--- a/Covid19Radar/Covid19Radar/ViewModels/NewsPage/NewsPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/NewsPage/NewsPageViewModel.cs
@@ -7,12 +7,22 @@ namespace Covid19Radar.ViewModels
 {
 	public class NewsPageViewModel : ViewModelBase
 	{
-		public static string Url { get; private set; }
+		public static string Url     { get; set; }
+		public static bool   GSearch { get; set; }
 
 		private readonly INavigationService _navigationService;
 
-		public Command OnClick_ShowPage => new Command(() => {
-			Url = AppResources.NewsPageUrl;
+		public Command OnClick_ShowGoogle => new Command(() => {
+			if (GSearch) {
+				GSearch = false;
+			} else {
+				Url = AppResources.GoogleSearchUrl;
+			}
+			_navigationService.NavigateAsync(nameof(WebViewerPage));
+		});
+
+		public Command OnClick_ShowCoronaGoJP => new Command(() => {
+			Url = AppResources.CoronaGoJPUrl;
 			_navigationService.NavigateAsync(nameof(WebViewerPage));
 		});
 

--- a/Covid19Radar/Covid19Radar/ViewModels/NewsPage/NewsPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/NewsPage/NewsPageViewModel.cs
@@ -1,0 +1,30 @@
+﻿using Covid19Radar.Resources;
+using Covid19Radar.Views;
+using Prism.Navigation;
+using Xamarin.Forms;
+
+namespace Covid19Radar.ViewModels
+{
+	public class NewsPageViewModel : ViewModelBase
+	{
+		public static string Url { get; private set; }
+
+		private readonly INavigationService _navigationService;
+
+		public Command OnClick_ShowPage => new Command(() => {
+			Url = AppResources.NewsPageUrl;
+			_navigationService.NavigateAsync(nameof(WebViewerPage));
+		});
+
+		public Command OnClick_ShowStopCOVID19JP => new Command(() => {
+			Url = AppResources.StopCOVID19JPUrl;
+			_navigationService.NavigateAsync(nameof(WebViewerPage));
+		});
+
+		public NewsPageViewModel(INavigationService navigationService) : base(navigationService)
+		{
+			_navigationService = navigationService;
+			this.Title = AppResources.NewsPageTitle;
+		}
+	}
+}

--- a/Covid19Radar/Covid19Radar/ViewModels/NewsPage/WebViewerPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/NewsPage/WebViewerPageViewModel.cs
@@ -1,0 +1,15 @@
+﻿using Covid19Radar.Resources;
+using Prism.Navigation;
+
+namespace Covid19Radar.ViewModels
+{
+	public class WebViewerPageViewModel : ViewModelBase
+	{
+		public string Url => NewsPageViewModel.Url;
+
+		public WebViewerPageViewModel(INavigationService navigationService) : base(navigationService)
+		{
+			this.Title = AppResources.NewsPageTitle;
+		}
+	}
+}

--- a/Covid19Radar/Covid19Radar/Views/NewsPage/NewsPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/NewsPage/NewsPage.xaml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+	x:Class="Covid19Radar.Views.NewsPage"
+	xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+	xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+	xmlns:prism="clr-namespace:Prism.Mvvm;assembly=Prism.Forms"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:resources="clr-namespace:Covid19Radar.Resources;assembly=Covid19Radar"
+	mc:Ignorable="d"
+	Title="{Binding Title}"
+	ios:Page.UseSafeArea="true"
+	prism:ViewModelLocator.AutowireViewModel="True"
+	Style="{StaticResource DefaultPageStyle}"
+	Visual="Material">
+	<ContentPage.Content>
+		<Grid Style="{StaticResource DefaultGridLayout}">
+			<ScrollView>
+				<StackLayout Style="{StaticResource DefaultStackLayout}">
+					<Button
+						Command="{Binding OnClick_ShowPage}"
+						Style="{StaticResource DefaultButton}"
+						Text="{x:Static resources:AppResources.NewsPageButton_ShowPage}" />
+					<Button
+						Command="{Binding OnClick_ShowStopCOVID19JP}"
+						Style="{StaticResource DefaultButton}"
+						Text="{x:Static resources:AppResources.NewsPageButton_ShowStopCOVID19JP}" />
+				</StackLayout>
+			</ScrollView>
+		</Grid>
+	</ContentPage.Content>
+</ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/NewsPage/NewsPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/NewsPage/NewsPage.xaml
@@ -14,18 +14,70 @@
 	prism:ViewModelLocator.AutowireViewModel="True"
 	Style="{StaticResource DefaultPageStyle}"
 	Visual="Material">
+	<ContentPage.Resources>
+		<ResourceDictionary>
+			<Style x:Key="BackgroundGrid" TargetType="Grid">
+				<Setter Property="VerticalOptions" Value="FillAndExpand" />
+				<Setter Property="ColumnSpacing"   Value="15" />
+				<Setter Property="RowSpacing"      Value="15" />
+				<Setter Property="Margin"          Value="0" />
+				<Setter Property="Padding"         Value="15" />
+				<Setter Property="BackgroundColor" Value="#EEEEEE" />
+			</Style>
+			<Style x:Key="ForegroundFrame" TargetType="Frame">
+				<Setter Property="Padding"      Value="10" />
+				<Setter Property="CornerRadius" Value="10" />
+				<Setter Property="HasShadow"    Value="False" />
+			</Style>
+		</ResourceDictionary>
+	</ContentPage.Resources>
 	<ContentPage.Content>
-		<Grid Style="{StaticResource DefaultGridLayout}">
+		<Grid Style="{StaticResource BackgroundGrid}">
 			<ScrollView>
-				<StackLayout Style="{StaticResource DefaultStackLayout}">
-					<Button
-						Command="{Binding OnClick_ShowPage}"
-						Style="{StaticResource DefaultButton}"
-						Text="{x:Static resources:AppResources.NewsPageButton_ShowPage}" />
-					<Button
-						Command="{Binding OnClick_ShowStopCOVID19JP}"
-						Style="{StaticResource DefaultButton}"
-						Text="{x:Static resources:AppResources.NewsPageButton_ShowStopCOVID19JP}" />
+				<StackLayout Margin="0" Padding="0" Spacing="15">
+					<Frame Style="{StaticResource ForegroundFrame}">
+						<StackLayout Style="{StaticResource DefaultStackLayout}">
+							<Label
+								Style="{StaticResource DefaultLabelLarge}"
+								Text="{x:Static resources:AppResources.NewsPageButton_ShowGoogle}" />
+							<SearchBar
+								x:Name="CovidSearchBar"
+								SearchButtonPressed="SearchBar_SearchButtonPressed" />
+						</StackLayout>
+					</Frame>
+					<Frame Style="{StaticResource ForegroundFrame}">
+						<StackLayout Style="{StaticResource DefaultStackLayout}">
+							<!-- TODO: ここに統計情報を取得して表示するコードを追加 -->
+							<!-- TODO: 以下のラベルは削除する -->
+							<Label Text="Error: could not load statistics." />
+							<Label Text="Error: could not draw graphs." />
+							<Label Text="エラー：統計情報を読み込めません。" />
+							<Label Text="エラー：グラフを描画できません。" />
+						</StackLayout>
+					</Frame>
+					<Frame Style="{StaticResource ForegroundFrame}">
+						<StackLayout Style="{StaticResource DefaultStackLayout}">
+							<Label
+								Style="{StaticResource DefaultLabelLarge}"
+								Text="{x:Static resources:AppResources.NewsPageLabel_Links}" />
+							<Label
+								Style="{StaticResource DefaultLabel}"
+								Text="{x:Static resources:AppResources.NewsPageLabel_LinksDescription}" />
+							<Button
+								x:Name="GSearchButton"
+								Command="{Binding OnClick_ShowGoogle}"
+								Style="{StaticResource DefaultButton}"
+								Text="{x:Static resources:AppResources.NewsPageButton_ShowGoogle}" />
+							<Button
+								Command="{Binding OnClick_ShowCoronaGoJP}"
+								Style="{StaticResource DefaultButton}"
+								Text="{x:Static resources:AppResources.NewsPageButton_ShowCoronaGoJP}" />
+							<Button
+								Command="{Binding OnClick_ShowStopCOVID19JP}"
+								Style="{StaticResource DefaultButton}"
+								Text="{x:Static resources:AppResources.NewsPageButton_ShowStopCOVID19JP}" />
+						</StackLayout>
+					</Frame>
 				</StackLayout>
 			</ScrollView>
 		</Grid>

--- a/Covid19Radar/Covid19Radar/Views/NewsPage/NewsPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/NewsPage/NewsPage.xaml
@@ -48,11 +48,6 @@
 					<Frame Style="{StaticResource ForegroundFrame}">
 						<StackLayout Style="{StaticResource DefaultStackLayout}">
 							<!-- TODO: ここに統計情報を取得して表示するコードを追加 -->
-							<!-- TODO: 以下のラベルは削除する -->
-							<Label Text="Error: could not load statistics." />
-							<Label Text="Error: could not draw graphs." />
-							<Label Text="エラー：統計情報を読み込めません。" />
-							<Label Text="エラー：グラフを描画できません。" />
 						</StackLayout>
 					</Frame>
 					<Frame Style="{StaticResource ForegroundFrame}">

--- a/Covid19Radar/Covid19Radar/Views/NewsPage/NewsPage.xaml.cs
+++ b/Covid19Radar/Covid19Radar/Views/NewsPage/NewsPage.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Covid19Radar.Views
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class NewsPage : ContentPage
+	{
+		public NewsPage()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/Covid19Radar/Covid19Radar/Views/NewsPage/NewsPage.xaml.cs
+++ b/Covid19Radar/Covid19Radar/Views/NewsPage/NewsPage.xaml.cs
@@ -1,4 +1,7 @@
-﻿using Xamarin.Forms;
+﻿using System;
+using Covid19Radar.Resources;
+using Covid19Radar.ViewModels;
+using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace Covid19Radar.Views
@@ -9,6 +12,13 @@ namespace Covid19Radar.Views
 		public NewsPage()
 		{
 			this.InitializeComponent();
+		}
+
+		private void SearchBar_SearchButtonPressed(object sender, EventArgs e)
+		{
+			NewsPageViewModel.Url     = $"{AppResources.GoogleSearchUrl}+{Uri.EscapeDataString(CovidSearchBar.Text)}";
+			NewsPageViewModel.GSearch = true;
+			GSearchButton.Command.Execute(null);
 		}
 	}
 }

--- a/Covid19Radar/Covid19Radar/Views/NewsPage/WebViewerPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/NewsPage/WebViewerPage.xaml
@@ -16,13 +16,11 @@
 	Visual="Material">
 	<ContentPage.Content>
 		<Grid Style="{StaticResource DefaultGridLayout}">
-			<ScrollView>
-				<StackLayout Style="{StaticResource DefaultStackLayout}">
-					<views:NavigatePopoverWebView
-						Source="{Binding Url}"
-						Style="{StaticResource DefaultWebView}" />
-				</StackLayout>
-			</ScrollView>
+			<StackLayout Style="{StaticResource DefaultStackLayout}">
+				<views:NavigatePopoverWebView
+					Source="{Binding Url}"
+					Style="{StaticResource DefaultWebView}" />
+			</StackLayout>
 		</Grid>
 	</ContentPage.Content>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/NewsPage/WebViewerPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/NewsPage/WebViewerPage.xaml
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+	x:Class="Covid19Radar.Views.WebViewerPage"
+	xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+	xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+	xmlns:prism="clr-namespace:Prism.Mvvm;assembly=Prism.Forms"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:views="clr-namespace:Covid19Radar.Views"
+	mc:Ignorable="d"
+	Title="{Binding Title}"
+	ios:Page.UseSafeArea="true"
+	prism:ViewModelLocator.AutowireViewModel="True"
+	Style="{StaticResource DefaultPageStyle}"
+	Visual="Material">
+	<ContentPage.Content>
+		<Grid Style="{StaticResource DefaultGridLayout}">
+			<ScrollView>
+				<StackLayout Style="{StaticResource DefaultStackLayout}">
+					<views:NavigatePopoverWebView
+						Source="{Binding Url}"
+						Style="{StaticResource DefaultWebView}" />
+				</StackLayout>
+			</ScrollView>
+		</Grid>
+	</ContentPage.Content>
+</ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/NewsPage/WebViewerPage.xaml.cs
+++ b/Covid19Radar/Covid19Radar/Views/NewsPage/WebViewerPage.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Covid19Radar.Views
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class WebViewerPage : ContentPage
+	{
+		public WebViewerPage()
+		{
+			this.InitializeComponent();
+		}
+	}
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* 最新情報を表示する為のページを追加しました。(#770)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
1. メニューを開く
2. 「最新情報」をタップ
3. 「最新情報をGoogleで検索」をタップ
    * Google検索で最新の情報を調べる事ができます。
    * 不具合で内部ブラウザを閉じてから左上の矢印をタップしないと最新情報ページに戻りません。
4. 「対策ダッシュボード」をタップ
    * https://stopcovid19.jp が開かれます。